### PR TITLE
Fix non secure network request

### DIFF
--- a/manifest/staging.js
+++ b/manifest/staging.js
@@ -9,7 +9,7 @@ export default Object.assign(
     'content_security_policy': csp({
       'directives': {
         'default-src': [
-          'https://staging.recommendations.lmem.net',
+          'https://preprod-lmem-craft-backend.cleverapps.io',
           'https://testing.ui.lmem.net',
         ],
         'script-src': [


### PR DESCRIPTION
SSL certificate is outdated for `staging.recommendations.lmem.net`.
`recommendations.lmem.net` is fine (handled by Cloudflare).