### PR TITLE
refactor(actions): implement flux standard actions

### DIFF
--- a/src/app/background/actions/init.js
+++ b/src/app/background/actions/init.js
@@ -1,0 +1,7 @@
+import { INIT } from '../../constants/ActionTypes';
+import createAction from '../../utils/createAction';
+
+export default createAction(
+  INIT, 
+  ({ onInstalledDetails, criteria, editors }) => ({ onInstalledDetails, criteria, editors }),
+);

--- a/src/app/background/actions/install.js
+++ b/src/app/background/actions/install.js
@@ -1,4 +1,7 @@
 import { INSTALLED } from '../../constants/ActionTypes';
+import createAction from '../../utils/createAction';
+
+export const installed = createAction(INSTALLED)(onInstalledDetails => ({ onInstalledDetails }));
 
 // Promise constructed when the module is first imported (very early)
 // in order to not miss the "install" event.
@@ -19,9 +22,6 @@ export default function ({ onboardingUrl }) {
       onInstalledPromise.then(() => chrome.tabs.create({ url: onboardingUrl }));
     }
 
-    onInstalledPromise.then(onInstalledDetails => dispatch({
-      type: INSTALLED,
-      onInstalledDetails
-    }));
+    onInstalledPromise.then(onInstalledDetails => dispatch(installed(onInstalledDetails)));
   };
 }

--- a/src/app/background/actions/publishToTab.js
+++ b/src/app/background/actions/publishToTab.js
@@ -1,0 +1,4 @@
+import createAction from '../../utils/createAction';
+import { PUBLISH_TO_TAB } from '../../constants/ActionTypes';
+
+export default createAction(PUBLISH_TO_TAB)(action => ({ action }));

--- a/src/app/background/actions/tabs.js
+++ b/src/app/background/actions/tabs.js
@@ -3,27 +3,20 @@ import {
   RECO_DISPLAYED,
   RECO_DISMISSED
 } from '../../constants/ActionTypes';
+import createAction from '../../utils/createAction';
 
-export function contextTriggered(trigger, triggeredContexts) {
-  return {
-    type: CONTEXT_TRIGGERED,
-    trigger,
-    triggeredContexts
-  };
-}
-
-export function recoDisplayed(trigger, recommendation) {
-  return {
-    type: RECO_DISPLAYED,
-    trigger,
-    recommendation
-  };
-}
-
-export function recoDismissed(trigger, recommendation) {
-  return {
-    type: RECO_DISMISSED,
-    trigger,
-    recommendation
-  };
-}
+export const contextTriggered = createAction(
+  CONTEXT_TRIGGERED,
+  (triggeredContexts = []) => ({ triggeredContexts }),
+  trigger => ({ trigger })
+);
+export const recoDisplayed = createAction(
+  RECO_DISPLAYED,
+  recommendation => ({ recommendation }),
+  trigger => ({ trigger })
+);
+export const recoDismissed = createAction(
+  RECO_DISMISSED,
+  recommendation => ({ recommendation }),
+  trigger => ({ trigger })
+);

--- a/src/app/background/actions/updateDraftRecommendations.js
+++ b/src/app/background/actions/updateDraftRecommendations.js
@@ -1,8 +1,4 @@
 import { UPDATE_DRAFT_RECOMMENDATIONS } from '../../constants/ActionTypes';
+import createAction from '../../utils/createAction';
 
-export default function (draftRecommendations) {
-  return {
-    type: UPDATE_DRAFT_RECOMMENDATIONS,
-    draftRecommendations
-  };
-}
+export default createAction(UPDATE_DRAFT_RECOMMENDATIONS)(draftRecommendations => ({ draftRecommendations }));

--- a/src/app/background/middlewares/refreshMatchingContexts.js
+++ b/src/app/background/middlewares/refreshMatchingContexts.js
@@ -1,5 +1,6 @@
 import { matchingTabIdToPortM } from '../tabs';
-import { refreshMatchingContextsFromBackend } from '../actions/kraftBackend';
+import { refreshMatchingContexts, refreshMatchingContextsFromBackend } from '../actions/kraftBackend';
+import publishToTab from '../actions/publishToTab';
 
 import {
   SELECT_CRITERION,
@@ -15,21 +16,18 @@ export default function (store){
     function scheduleRefreshAfterward() {
       const result = next(action);
 
-      store.dispatch({ type: REFRESH_MATCHING_CONTEXTS });
+      store.dispatch(refreshMatchingContexts());
 
       return result;
     }
 
-    function refreshMatchingContexts() {
+    function updateMatchingContexts() {
       const state = store.getState();
 
       // update all content stores
       matchingTabIdToPortM.forEach((tabPortP) => {
         tabPortP
-          .then(tabPort => tabPort.postMessage({
-            type: 'dispatch',
-            action
-          }));
+          .then(tabPort => tabPort.postMessage(publishToTab(action)));
       });
 
       const selectedCriteria = Array.from(state.get('prefs').get('criteria').keys())
@@ -55,7 +53,7 @@ export default function (store){
         return scheduleRefreshAfterward();
 
       case REFRESH_MATCHING_CONTEXTS:
-        return refreshMatchingContexts();
+        return updateMatchingContexts();
 
       default:
         return next(action);

--- a/src/app/background/middlewares/sendFeedback.js
+++ b/src/app/background/middlewares/sendFeedback.js
@@ -39,14 +39,15 @@ export function makeRecoFeedback(type, url) {
 
 export default function (store){
   return next => (action) => {
+    const { type, payload } = action;
 
-    switch (action.type){
+    switch (type){
       case DISMISS_RECO:
       case APPROVE_RECO:
       case UNAPPROVE_RECO:
       case REPORT_RECO:
-
-        const reqUrl = LMEM_BACKEND_ORIGIN + '/api/v2/recommendations/' + action.id + '/feedbacks';
+        const { id } = payload;
+        const reqUrl = LMEM_BACKEND_ORIGIN + '/api/v2/recommendations/' + id + '/feedbacks';
         const tabUrlP = new Promise((res) => {
           chrome.tabs.query({
             active: true,
@@ -55,7 +56,7 @@ export default function (store){
         });
         
         tabUrlP.then((tabUrl) => {
-          const body = JSON.stringify(makeRecoFeedback(action.type, tabUrl));
+          const body = JSON.stringify(makeRecoFeedback(type, tabUrl));
 
           fetch(reqUrl, { method: 'POST', body })
             .then(response => console.log('RESPONSE', response))

--- a/src/app/background/reducers/prefs.js
+++ b/src/app/background/reducers/prefs.js
@@ -27,18 +27,18 @@ const initialPrefs = fromJS({
 });
 
 export default function (state = initialPrefs, action) {
-  const { type } = action;
+  const { type, payload } = action;
 
   console.log('reducer', type, action);
 
   switch (type) {
     case INSTALLED: {
-      const { onInstalledDetails } = action;
+      const { onInstalledDetails } = payload;
       return state.set('onInstalledDetails', ImmutableMap(onInstalledDetails)); // eslint-disable-line
     }
 
     case RECEIVED_CRITERIA: {
-      const { criteria } = action;
+      const { criteria } = payload;
       let newCriteria;
 
       newCriteria = criteria.reduce((acc, curr) => {
@@ -54,7 +54,7 @@ export default function (state = initialPrefs, action) {
     }
 
     case SELECT_CRITERION: {
-      const { slug } = action;
+      const { slug } = payload;
       const criteria = state.get('criteria');
 
       return state.set('criteria', criteria.setIn([slug, 'isSelected'], true));
@@ -68,10 +68,10 @@ export default function (state = initialPrefs, action) {
     }
 
     case RECEIVED_EDITORS: {
-      const { editors } = action;
+      const { editors } = payload;
       let newEditors;
 
-      newEditors = editors.reduce((acc, curr) => { 
+      newEditors = editors.reduce((acc, curr) => {
         const id = curr.get('id').toString();
 
         return !state.get('editors').has(id)
@@ -84,14 +84,14 @@ export default function (state = initialPrefs, action) {
     }
 
     case EXCLUDE_EDITOR: {
-      const { id } = action;
+      const { id } = payload;
       const editors = state.get('editors');
 
       return state.set('editors', editors.setIn([id.toString(), 'isExcluded'], true));
     }
 
     case INCLUDE_EDITOR: {
-      const { id } = action;
+      const { id } = payload;
       const editors = state.get('editors');
 
       return state.set('editors', editors.setIn([id.toString(), 'isExcluded'], false));
@@ -99,28 +99,28 @@ export default function (state = initialPrefs, action) {
 
     case DISMISS_RECO:
     case REPORT_RECO: {
-      const { id } = action;
+      const { id } = payload;
       const dismissedRecos = state.get('dismissedRecos');
 
       return state.set('dismissedRecos', dismissedRecos.add(id));
     }
 
     case APPROVE_RECO: {
-      const { id } = action;
+      const { id } = payload;
       const approvedRecos = state.get('approvedRecos');
 
       return state.set('approvedRecos', approvedRecos.add(id));
     }
 
     case UNAPPROVE_RECO: {
-      const { id } = action;
+      const { id } = payload;
       const approvedRecos = state.get('approvedRecos');
 
       return state.set('approvedRecos', approvedRecos.delete(id));
     }
 
     case DEACTIVATE: {
-      const { duration } = action;
+      const { duration } = payload;
 
       return state.setIn(['websites', 'deactivated', 'everywhereUntil'], Date.now() + duration);
     }

--- a/src/app/background/reducers/resources.js
+++ b/src/app/background/reducers/resources.js
@@ -13,17 +13,17 @@ const initialResources = fromJS({
 });
 
 export default function (state = initialResources, action) {
-  const { type } = action;
+  const { type, payload } = action;
 
   console.log('reducer', type, action);
 
   switch (type) {
     case RECEIVED_MATCHING_CONTEXTS:
-      const { matchingContexts } = action;
+      const { matchingContexts } = payload;
       return state.set('matchingContexts', matchingContexts);
 
     case UPDATE_DRAFT_RECOMMENDATIONS: {
-      const { draftRecommendations } = action;
+      const { draftRecommendations } = payload;
 
       return state.set('draftRecommendations', draftRecommendations);
     }

--- a/src/app/background/store/configureStore.js
+++ b/src/app/background/store/configureStore.js
@@ -53,7 +53,7 @@ export default function configureStore(callback, isBg) {
     const enhancer = process.env.NODE_ENV !== 'production'
       ? composeEnhancers(applyMiddleware(...middlewares.concat([
         require('redux-immutable-state-invariant').default(), // eslint-disable-line
-        require('redux-logger').createLogger({ level: 'info', collapsed: true }), // eslint-disable-line
+        require('redux-logger').createLogger({ level: 'info', collapsed: true, stateTransformer: state => state.toJS() }), // eslint-disable-line
       ])))
       : applyMiddleware(...middlewares);
 

--- a/src/app/constants/ActionTypes.js
+++ b/src/app/constants/ActionTypes.js
@@ -1,5 +1,9 @@
 // background actions
 
+export const INIT = 'init';
+export const PUBLISHED_FROM_TAB = 'redux-action';
+export const PUBLISH_TO_TAB = 'PUBLISH_TO_TAB';
+
 export const MATCHING_OFFERS_FOUND = 'matching_offers/FOUND';
 
 export const RECEIVED_MATCHING_CONTEXTS = 'api/UPDATE_MATCHING_CONTEXTS';

--- a/src/app/content/actions/filters.js
+++ b/src/app/content/actions/filters.js
@@ -8,79 +8,17 @@ import {
   EXCLUDE_EDITOR,
   INCLUDE_EDITOR
 } from '../../constants/ActionTypes';
+import createAction from '../../utils/createAction';
+import createBackgroundAction from '../createBackgroundAction';
 
-export default function (portCommunication) {
-  return {
-    updateDeactivatedWebsites(deactivatedWebsites) {
-      return {
-        type: DEACTIVATED_WEBSITES,
-        deactivatedWebsites
-      };
-    },
-    
-    updateInstalledDetails(onInstalledDetails) {
-      return {
-        type: INSTALLED_DETAILS,
-        onInstalledDetails
-      };
-    },
-    
-    updateCriteria(criteria) {
-      return {
-        type: CRITERIA,
-        criteria
-      };
-    },
-
-    selectCriterion(slug) {
-      const action = {
-        type: SELECT_CRITERION,
-        slug
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-      
-      return action;
-    },
-
-    unselectCriterion(slug) {
-      const action = {
-        type: UNSELECT_CRITERION,
-        slug
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-      
-      return action;
-    },
-
-    updateEditors(editors) {
-      return {
-        type: EDITORS,
-        editors
-      };
-    },
-
-    excludeEditor(id) {
-      const action = {
-        type: EXCLUDE_EDITOR,
-        id
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-      
-      return action;
-    },
-
-    includeEditor(id) {
-      const action = {
-        type: INCLUDE_EDITOR,
-        id
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-      
-      return action;
-    }
-  };
-}
+export const updateDeactivatedWebsites = createAction(
+  DEACTIVATED_WEBSITES,
+  deactivatedWebsites => ({ deactivatedWebsites })
+);
+export const updateInstalledDetails = createAction(INSTALLED_DETAILS, onInstalledDetails => ({ onInstalledDetails }));
+export const updateCriteria = createAction(CRITERIA, criteria => ({ criteria }));
+export const selectCriterion = createBackgroundAction(SELECT_CRITERION, slug => ({ slug }));
+export const unselectCriterion = createBackgroundAction(UNSELECT_CRITERION, slug => ({ slug }));
+export const updateEditors = createAction(EDITORS, (editors = []) => ({ editors }));
+export const excludeEditor = createBackgroundAction(EXCLUDE_EDITOR, id => ({ id }));
+export const includeEditor = createBackgroundAction(INCLUDE_EDITOR, id => ({ id }));

--- a/src/app/content/actions/publish.js
+++ b/src/app/content/actions/publish.js
@@ -1,0 +1,4 @@
+import createAction from '../../utils/createAction';
+import { PUBLISHED_FROM_TAB } from '../../constants/ActionTypes';
+
+export default createAction(PUBLISHED_FROM_TAB);

--- a/src/app/content/actions/recommendations.js
+++ b/src/app/content/actions/recommendations.js
@@ -5,54 +5,11 @@ import {
   UNAPPROVE_RECO,
   REPORT_RECO,
 } from '../../constants/ActionTypes';
+import createAction from '../../utils/createAction';
+import createBackgroundAction from '../createBackgroundAction';
 
-export default function (portCommunication) {
-  return {
-    recommendationFound(recommendations){
-      return {
-        type: RECOMMENDATION_FOUND,
-        recommendations
-      };
-    },
-    dismissReco(id){
-      const action = {
-        type: DISMISS_RECO,
-        id
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-    approveReco(id){
-      const action = {
-        type: APPROVE_RECO,
-        id
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-    unapproveReco(id){
-      const action = {
-        type: UNAPPROVE_RECO,
-        id
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-    reportReco(id){
-      const action = {
-        type: REPORT_RECO,
-        id
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    }
-  };
-}
+export const recommendationFound = createAction(RECOMMENDATION_FOUND, (recommendations = []) => ({ recommendations }));
+export const dismissReco = createBackgroundAction(DISMISS_RECO, id => ({ id }));
+export const approveReco = createBackgroundAction(APPROVE_RECO, id => ({ id }));
+export const unapproveReco = createBackgroundAction(UNAPPROVE_RECO, id => ({ id }));
+export const reportReco = createBackgroundAction(REPORT_RECO, id => ({ id }));

--- a/src/app/content/actions/ui.js
+++ b/src/app/content/actions/ui.js
@@ -11,128 +11,16 @@ import {
   CHECKOUT_RECO_EDITOR,
   POPUP_CLICK,
 } from '../../constants/ActionTypes';
+import createBackgroundAction from '../createBackgroundAction';
 
-export default function (portCommunication) {
-  return {
-    reduce() {
-      const action = {
-        type: REDUCE_RECOMMENDATION_IFRAME
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    extend() {
-      const action = {
-        type: EXTEND_RECOMMENDATION_IFRAME
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-      
-      return action;
-    },
-
-    deactivate(details) {
-      const action = Object.assign(
-        { type: DEACTIVATE },
-        details
-      );
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    closePrefScreen(){
-      const action = {
-        type: CLOSE_PREFERENCE_PANEL
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-    
-    openPrefScreen(panel){
-      const action = {
-        type: OPEN_PREFERENCE_PANEL,
-        panel
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    checkOutResourceButton(resource) {
-      const action = {
-        type: CHECKOUT_RECO_RESOURCE_BUTTON,
-        resource,
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    checkOutResourceLink(resource) {
-      const action = {
-        type: CHECKOUT_RECO_RESOURCE_LINK,
-        resource,
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    checkOutAlternative(alternative) {
-      const action = {
-        type: CHECKOUT_RECO_ALTERNATIVE,
-        alternative,
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    checkOutEditor(editor) {
-      const action = {
-        type: CHECKOUT_RECO_EDITOR,
-        editor,
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    uninstall() {
-      const action = {
-        type: UNINSTALL,
-        datetime: new Date(),
-      };
-      
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-
-    popupClick(target) {
-      const action = {
-        type: POPUP_CLICK,
-        target,
-      };
-
-      if (portCommunication) portCommunication.sendBackgroundReduxAction(action);
-
-      return action;
-    },
-  };
-}
-
-
-
+export const reduce = createBackgroundAction(REDUCE_RECOMMENDATION_IFRAME);
+export const extend = createBackgroundAction(EXTEND_RECOMMENDATION_IFRAME);
+export const deactivate = createBackgroundAction(DEACTIVATE, ({ where, duration }) => ({ where, duration }));
+export const closePrefScreen = createBackgroundAction(CLOSE_PREFERENCE_PANEL);
+export const openPrefScreen = createBackgroundAction(OPEN_PREFERENCE_PANEL, panel => ({ panel }));
+export const checkOutResourceButton = createBackgroundAction(CHECKOUT_RECO_RESOURCE_BUTTON, resource => ({ resource }));
+export const checkOutResourceLink = createBackgroundAction(CHECKOUT_RECO_RESOURCE_LINK, resource => ({ resource }));
+export const checkOutAlternative = createBackgroundAction(CHECKOUT_RECO_ALTERNATIVE, alternative => ({ alternative }));
+export const checkOutEditor = createBackgroundAction(CHECKOUT_RECO_EDITOR, editor => ({ editor }));
+export const uninstall = createBackgroundAction(UNINSTALL, () => ({ datetime: new Date() }));
+export const popupClick = createBackgroundAction(POPUP_CLICK, target => ({ target }));

--- a/src/app/content/components/RecoMain.js
+++ b/src/app/content/components/RecoMain.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -115,5 +115,5 @@ export default function RecoMain({
 
 RecoMain.propTypes = {
   imagesUrl: PropTypes.string.isRequired,
-  recommendations: PropTypes.arrayOf(RecommendationPropType).isRequired,
+  recommendations: PropTypes.arrayOf(PropTypes.shape(RecommendationPropType)).isRequired,
 };

--- a/src/app/content/containers/App.js
+++ b/src/app/content/containers/App.js
@@ -1,12 +1,7 @@
 import { connect } from 'react-redux';
 
 import Recommendations from '../components/Recommendations';
-import prepareUIActions from '../actions/ui';
-
-import { IMAGES_URL } from '../../constants/assetsUrls';
-import portCommunication from '../portCommunication';
-
-const {
+import {
   reduce,
   extend,
   deactivate,
@@ -16,7 +11,8 @@ const {
   checkOutResourceLink,
   checkOutAlternative,
   checkOutEditor
-} = prepareUIActions(portCommunication);
+} from '../actions/ui';
+import { IMAGES_URL } from '../../constants/assetsUrls';
 
 function mapStateToProps(state) {
   return {

--- a/src/app/content/containers/Feedback.js
+++ b/src/app/content/containers/Feedback.js
@@ -1,18 +1,8 @@
 import { connect } from 'react-redux';
 
-import prepareRecoActions from '../actions/recommendations';
-
+import { dismissReco, approveReco, unapproveReco, reportReco } from '../actions/recommendations';
 import { IMAGES_URL } from '../../constants/assetsUrls';
-import portCommunication from '../portCommunication';
-
 import FeedbackButtons from '../components/FeedbackButtons';
-
-const {
-  dismissReco,
-  approveReco,
-  unapproveReco,
-  reportReco
-} = prepareRecoActions(portCommunication);
 
 function mapStateToProps(state, ownProps) {
   return Object.assign({}, ownProps, {

--- a/src/app/content/containers/Preferences.js
+++ b/src/app/content/containers/Preferences.js
@@ -1,24 +1,14 @@
 import { connect } from 'react-redux';
 
 import PreferenceScreen from '../components/PreferenceScreen';
-import uiActions from '../actions/ui';
-import filterActions from '../actions/filters';
-
-import { IMAGES_URL } from '../../constants/assetsUrls';
-import portCommunication from '../portCommunication';
-
-const {
+import { closePrefScreen, openPrefScreen, uninstall } from '../actions/ui';
+import {
   selectCriterion,
   unselectCriterion,
   excludeEditor,
   includeEditor
-} = filterActions(portCommunication);
-
-const {
-  closePrefScreen,
-  openPrefScreen,
-  uninstall,
-} = uiActions(portCommunication);
+} from '../actions/filters';
+import { IMAGES_URL } from '../../constants/assetsUrls';
 
 function mapStateToProps(state) {
   return {

--- a/src/app/content/createBackgroundAction.js
+++ b/src/app/content/createBackgroundAction.js
@@ -1,0 +1,8 @@
+import createAction from '../utils/createAction';
+import identity from '../utils/identity';
+
+export default (
+  type,
+  payloadCreator = identity,
+  metaCreator = () => ({ background: true })
+) => createAction(type, payloadCreator, metaCreator);

--- a/src/app/content/middlewares/backgroundPublisher.js
+++ b/src/app/content/middlewares/backgroundPublisher.js
@@ -1,0 +1,20 @@
+export const transformBackgroundAction = (action) => {
+  const { type, payload, meta } = action;
+  const { background, ...metaRest } = meta;
+
+  return {
+    type,
+    payload,
+    meta: { ...metaRest, fromTab: true }
+  };
+};
+
+export default portCommunication => store => next => (action) => {
+  const { meta } = action;
+
+  if (meta && meta.background) {
+    portCommunication.sendBackgroundReduxAction(transformBackgroundAction(action));
+  }
+
+  return next(action);
+};

--- a/src/app/content/middlewares/index.js
+++ b/src/app/content/middlewares/index.js
@@ -1,0 +1,4 @@
+import backgroundPublisher from './backgroundPublisher';
+import portCommunication from '../portCommunication';
+
+export default [backgroundPublisher(portCommunication), require('redux-logger').createLogger({ level: 'info', collapsed: true, stateTransformer: state => state.toJS() })];

--- a/src/app/content/portCommunication.js
+++ b/src/app/content/portCommunication.js
@@ -1,13 +1,11 @@
+import publish from './actions/publish';
+
 export default {
   port: undefined,
 
   postMessage(msg) { this.port.postMessage(msg); },
 
   sendBackgroundReduxAction(backgroundAction) {
-    this.postMessage({
-      type: 'redux-action',
-      action: backgroundAction
-    });
+    this.postMessage(publish(backgroundAction));
   }
-
 };

--- a/src/app/content/reducers/index.js
+++ b/src/app/content/reducers/index.js
@@ -16,11 +16,11 @@ import {
 } from '../../constants/ActionTypes';
 
 export default function (state = {}, action) {
-  const { type } = action;
+  const { type, payload } = action;
 
   switch (type) {
     case RECOMMENDATION_FOUND:
-      const { recommendations } = action;
+      const { recommendations } = payload;
       return state.set('recommendations', recommendations).set('reduced', false);
 
     case REDUCE_RECOMMENDATION_IFRAME:
@@ -36,7 +36,7 @@ export default function (state = {}, action) {
       return state.set('open', false);
 
     case INSTALLED_DETAILS:
-      const { onInstalledDetails } = action;
+      const { onInstalledDetails } = payload;
       return state.set('onInstalledDetails', onInstalledDetails);
 
     case CRITERIA: {
@@ -45,33 +45,33 @@ export default function (state = {}, action) {
     }
 
     case SELECT_CRITERION: {
-      const { slug } = action;
+      const { slug } = payload;
       const criteria = state.get('criteria');
 
       return state.set('criteria', criteria.setIn([slug, 'isSelected'], true));
     }
 
     case UNSELECT_CRITERION: {
-      const { slug } = action;
+      const { slug } = payload;
       const criteria = state.get('criteria');
 
       return state.set('criteria', criteria.setIn([slug, 'isSelected'], false));
     }
 
     case EDITORS: {
-      const { editors } = action;
+      const { editors } = payload;
       return state.set('editors', editors);
     }
 
     case EXCLUDE_EDITOR: {
-      const { id } = action;
+      const { id } = payload;
       const editors = state.get('editors');
 
       return state.set('editors', editors.setIn([id.toString(), 'isExcluded'], true));
     }  
 
     case INCLUDE_EDITOR: {
-      const { id } = action;
+      const { id } = payload;
       const editors = state.get('editors');
 
       return state.set('editors', editors.setIn([id.toString(), 'isExcluded'], false));

--- a/src/app/content/store.js
+++ b/src/app/content/store.js
@@ -1,6 +1,7 @@
-import { createStore } from 'redux';
+import { applyMiddleware, createStore} from 'redux';
 import { Record, Map as ImmutableMap } from 'immutable';
 import rootReducer from './reducers';
+import middlewares from './middlewares';
 
 export default createStore(
   rootReducer,
@@ -12,5 +13,6 @@ export default createStore(
     onInstalledDetails: new ImmutableMap(),
     criteria: new ImmutableMap(),
     editors: new ImmutableMap(),
-  })()
+  })(),
+  applyMiddleware(...middlewares)
 );

--- a/src/app/options/OptionRoot.js
+++ b/src/app/options/OptionRoot.js
@@ -5,22 +5,11 @@ import { hot } from 'react-hot-loader';
 import { ThemeProvider } from 'styled-components';
 
 import OptionScreen from './OptionScreen';
-import filterActions from '../content/actions/filters';
-import uiActions from '../content/actions/ui';
-
+import {
+  selectCriterion, unselectCriterion, excludeEditor, includeEditor 
+} from '../content/actions/filters';
+import { uninstall } from '../content/actions/ui';
 import { IMAGES_URL } from '../constants/assetsUrls';
-
-const {
-  selectCriterion,
-  unselectCriterion,
-  excludeEditor,
-  includeEditor
-} = filterActions(undefined);
-
-const {
-  uninstall
-} = uiActions(undefined);
-
 
 function mapStateToProps(state) {
   return {

--- a/src/app/popup/PopupRoot.js
+++ b/src/app/popup/PopupRoot.js
@@ -5,19 +5,12 @@ import { hot } from 'react-hot-loader';
 import { ThemeProvider } from 'styled-components';
 
 import PopupScreen from './PopupScreen';
-import uiActions from '../content/actions/ui';
-
+import { openPrefScreen, popupClick } from '../content/actions/ui';
 import { IMAGES_URL } from '../constants/assetsUrls';
 import {
   PREFERENCE_SCREEN_PANEL_ABOUT,
   PREFERENCE_SCREEN_PANEL_SOURCES,
 } from '../constants/ui';
-
-const {
-  openPrefScreen,
-  popupClick,
-} = uiActions();
-
 
 function mapStateToProps(state) {
   return {

--- a/src/app/utils/createAction.js
+++ b/src/app/utils/createAction.js
@@ -1,0 +1,22 @@
+import identity from './identity';
+
+export default (type, payloadCreator = identity, metaCreator = identity) => (payload, meta) => {
+  const action = { type };
+
+  if (payload !== undefined) {
+    action.payload = payloadCreator(payload);
+  }
+
+  if (metaCreator) {
+    const actionMeta = metaCreator(meta);
+    if (actionMeta !== undefined) {
+      action.meta = actionMeta;
+    }
+  }
+
+  if (payload instanceof Error) {
+    action.error = true;
+  }
+
+  return action;
+};

--- a/src/app/utils/identity.js
+++ b/src/app/utils/identity.js
@@ -1,0 +1,1 @@
+export default me => me;

--- a/test/app/actions.js
+++ b/test/app/actions.js
@@ -2,8 +2,6 @@ import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import { Set as ImmutableSet } from 'immutable';
-
 import {
   receivedMatchingContexts,
   receivedCriteria,
@@ -28,8 +26,7 @@ describe('background actions', function () {
     const action = receivedMatchingContexts(matchingContexts);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.matchingContexts).to.be.an.instanceof(ImmutableSet);
-    expect(action.matchingContexts.size).to.equal(matchingContexts.length);
+    expect(action.payload.matchingContexts).to.equal(matchingContexts);
   });
 
   it('receivedCriteria', () => {
@@ -37,7 +34,7 @@ describe('background actions', function () {
     const action = receivedCriteria(criteria);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.criteria).to.equal(criteria);
+    expect(action.payload.criteria).to.equal(criteria);
   });
 
   it('receivedEditors', () => {
@@ -45,37 +42,37 @@ describe('background actions', function () {
     const action = receivedEditors(editors);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.editors).to.equal(editors);
+    expect(action.payload.editors).to.equal(editors);
   });
   
   it('contextTriggered', () => {
     const trigger = '';
     const triggeredContexts = [];
-    const action = contextTriggered(trigger, triggeredContexts);
+    const action = contextTriggered(triggeredContexts, trigger);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.trigger).to.equal(trigger);
-    expect(action.triggeredContexts).to.equal(triggeredContexts);
+    expect(action.meta.trigger).to.equal(trigger);
+    expect(action.payload.triggeredContexts).to.equal(triggeredContexts);
   });
 
   it('recoDisplayed', () => {
     const trigger = '';
     const recommendation = {};
-    const action = recoDisplayed(trigger, recommendation);
+    const action = recoDisplayed(recommendation, trigger);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.trigger).to.equal(trigger);
-    expect(action.recommendation).to.equal(recommendation);
+    expect(action.meta.trigger).to.equal(trigger);
+    expect(action.payload.recommendation).to.equal(recommendation);
   });
 
   it('recoDismissed', () => {
     const trigger = '';
     const recommendation = {};
-    const action = recoDismissed(trigger, recommendation);
+    const action = recoDismissed(recommendation, trigger);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.trigger).to.equal(trigger);
-    expect(action.recommendation).to.equal(recommendation);
+    expect(action.meta.trigger).to.equal(trigger);
+    expect(action.payload.recommendation).to.equal(recommendation);
   });
 
   describe('auto refresh matching contexts', () => {

--- a/test/app/content/actions.js
+++ b/test/app/content/actions.js
@@ -1,20 +1,30 @@
 import chai from 'chai';
 
-import neverThrowingObject from '../../infrastructure/neverThrowingObject';
-
-import prepareRecoEvents from '../../../src/app/content/actions/recommendations';
-import prepareUIEvents from '../../../src/app/content/actions/ui';
-import prepareFilterEvents from '../../../src/app/content/actions/filters';
+import {
+  recommendationFound,
+  dismissReco,
+  approveReco,
+  reportReco
+} from '../../../src/app/content/actions/recommendations';
+import { reduce, extend, deactivate } from '../../../src/app/content/actions/ui';
+import {
+  updateCriteria,
+  updateEditors,
+  selectCriterion,
+  unselectCriterion,
+  excludeEditor,
+  includeEditor
+} from '../../../src/app/content/actions/filters';
+import init from '../../../src/app/background/actions/init';
 
 const expect = chai.expect;
 
-const {reduce, extend, deactivate} = prepareUIEvents(neverThrowingObject());
-const { updateCriteria, updateEditors,
-  selectCriterion, unselectCriterion,
-  excludeEditor, includeEditor } = prepareFilterEvents(neverThrowingObject());
-const { recommendationFound, dismissReco, approveReco, reportReco } = prepareRecoEvents(neverThrowingObject());
-
 describe('content actions', function () {
+  it('init', () => {
+    const payload = [{}, [], []];
+    const action = init(...payload);
+    expect(action.payload).to.be.an('object').to.include.all.keys('onInstalledDetails', 'criteria', 'editors');
+  })
 
   it('recommendationFound', () => {
     const recos = [{}, {}];
@@ -23,7 +33,7 @@ describe('content actions', function () {
     const action = recommendationFound(recos);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.recommendations).to.equal(recos);
+    expect(action.payload.recommendations).to.equal(recos);
   });
 
   it('reduce', () => {
@@ -50,7 +60,7 @@ describe('content actions', function () {
     const action = updateCriteria(criteria);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.criteria).to.equal(criteria);
+    expect(action.payload.criteria).to.equal(criteria);
   });
 
   it('select criterion', () => {
@@ -58,7 +68,7 @@ describe('content actions', function () {
     const action = selectCriterion(slug);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.slug).to.equal(slug);
+    expect(action.payload.slug).to.equal(slug);
   });
 
   it('unselect criterion', () => {
@@ -66,7 +76,7 @@ describe('content actions', function () {
     const action = unselectCriterion(slug);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.slug).to.equal(slug);
+    expect(action.payload.slug).to.equal(slug);
   });
 
   it('update editor', () => {
@@ -74,7 +84,7 @@ describe('content actions', function () {
     const action = updateEditors(editors);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.editors).to.equal(editors);
+    expect(action.payload.editors).to.equal(editors);
   });
 
   it('exclude editor', () => {
@@ -82,7 +92,7 @@ describe('content actions', function () {
     const action = excludeEditor(id);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.id).to.equal(id);
+    expect(action.payload.id).to.equal(id);
   });
 
   it('include editor', () => {
@@ -90,7 +100,7 @@ describe('content actions', function () {
     const action = includeEditor(id);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.id).to.equal(id);
+    expect(action.payload.id).to.equal(id);
   });
 
   it('dismiss reco', () => {
@@ -98,7 +108,7 @@ describe('content actions', function () {
     const action = dismissReco(id);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.id).to.equal(id);
+    expect(action.payload.id).to.equal(id);
   });
 
   it('approve reco', () => {
@@ -106,7 +116,7 @@ describe('content actions', function () {
     const action = approveReco(id);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.id).to.equal(id);
+    expect(action.payload.id).to.equal(id);
   });
 
   it('report reco', () => {
@@ -114,7 +124,7 @@ describe('content actions', function () {
     const action = reportReco(id);
 
     expect(action.type).to.be.a('string').of.length.above(5);
-    expect(action.id).to.equal(id);
+    expect(action.payload.id).to.equal(id);
   });
 
 });

--- a/test/app/content/reducers.js
+++ b/test/app/content/reducers.js
@@ -1,14 +1,9 @@
 import chai from 'chai';
-import neverThrowingObject from '../../infrastructure/neverThrowingObject';
-import prepareFilterEvents from '../../../src/app/content/actions/filters';
-
 import { Map as ImmutableMap } from 'immutable';
-
+import { excludeEditor, includeEditor } from '../../../src/app/content/actions/filters';
 import reducer from '../../../src/app/content/reducers/';
 
 const expect = chai.expect;
-
-const { excludeEditor, includeEditor } = prepareFilterEvents(neverThrowingObject());
 
 describe('content reducer', function () {
 

--- a/test/app/reducers.js
+++ b/test/app/reducers.js
@@ -1,6 +1,4 @@
 import chai from 'chai';
-import neverThrowingObject from '../infrastructure/neverThrowingObject';
-
 import { Map as ImmutableMap, Set as ImmutableSet, fromJS } from 'immutable';
 
 import prefsReducer from '../../src/app/background/reducers/prefs';
@@ -14,28 +12,23 @@ import {
   receivedEditors,
 } from '../../src/app/background/actions/kraftBackend';
 
-import prepareUIEvents from '../../src/app/content/actions/ui';
-import prepareFilterEvents from '../../src/app/content/actions/filters';
-import prepareRecoEvents from '../../src/app/content/actions/recommendations';
+import { deactivate } from '../../src/app/content/actions/ui';
+import { excludeEditor, includeEditor } from '../../src/app/content/actions/filters';
+import { dismissReco, approveReco, unapproveReco, reportReco } from '../../src/app/content/actions/recommendations';
 import { DEACTIVATE_EVERYWHERE, DEACTIVATE_WEBSITE_ALWAYS } from '../../src/app/constants/websites';
 
 const expect = chai.expect;
 
-const { deactivate } = prepareUIEvents(neverThrowingObject());
-const { excludeEditor, includeEditor } = prepareFilterEvents(neverThrowingObject());
-const { dismissReco, approveReco, unapproveReco, reportReco } = prepareRecoEvents(neverThrowingObject());
-
-
 describe('background reducer', function () {
 
   it('initial state + receivedMatchingContexts => state with offers', () => {
-    const matchingContexts = [{}, {}];
+    const matchingContexts = new ImmutableSet([{}, {}]);
     const action = receivedMatchingContexts(matchingContexts);
 
     const nextState = resourcesReducer( makeInitialState().get('resources'), action );
     
-    expect(action.matchingContexts).to.be.an.instanceof(ImmutableSet);
-    expect(nextState.get('matchingContexts')).to.have.size(matchingContexts.length);
+    expect(action.payload.matchingContexts).to.be.an.instanceof(ImmutableSet);
+    expect(nextState.get('matchingContexts')).to.have.size(matchingContexts.size);
   });
 
   it('initial state + criteria => state with criteria', () => {


### PR DESCRIPTION
All actions are now created by the same action creator `createAction`.
The middleware `forward` has been created in the `content` context,
it forwards to the `background` context the actions which have the
`forward` flag to `true` in their meta object.
It reduces greatly the boilerplate used to forward these actions as
well as insuring the separation of concerns.

Resolve #183 by implementing the proposal.