### PR TITLE
feat(details): remove approves/dislikes count from details

### DIFF
--- a/src/components/organisms/NoticeDetails.js
+++ b/src/components/organisms/NoticeDetails.js
@@ -69,7 +69,7 @@ class NoticeDetails extends PureComponent {
 
   render() {
     const {
-      type, date, message, contributor, source, approves, dislikes, approved
+      type, date, message, contributor, source, approved
     } = this.props;
 
     return (
@@ -99,11 +99,9 @@ class NoticeDetails extends PureComponent {
           <Feedbacks>
             <Button onClick={this.handleApprove}>
               <Approval active={approved === true} />
-              {approves}
             </Button>
             <Button onClick={this.handleDisapprove}>
               <Disapproval active={approved === false} />
-              {dislikes}
             </Button>
           </Feedbacks>
 


### PR DESCRIPTION
Since we're not able to get approves and dislikes count from API (in V2), let's hide them. 