### PR TITLE
fix: keep passed metas in background actions

### DIFF
--- a/src/app/content/createBackgroundAction.js
+++ b/src/app/content/createBackgroundAction.js
@@ -4,5 +4,5 @@ import identity from '../utils/identity';
 export default (
   type,
   payloadCreator = identity,
-  metaCreator = () => ({ background: true })
+  metaCreator = (meta) => (meta ? { ...meta, background: true } : { background: true })
 ) => createAction(type, payloadCreator, metaCreator);


### PR DESCRIPTION
Currently, any Redux action creator generated with the `createBackgroundAction` helper discards any passed metas to set only `{ background: true }`. 

It may not be a problem right now, but it doesn't feel to be what's expected when you call the action creator with some meta. 

This change keeps the passed metas, and only add or overwrite the `background` property to `true`. 

This does nothing if `metas` are `null` or `undefined`. 