### PR TITLE
fix(toolbar): close the notification upon toolbar click, if already open

### DIFF
--- a/src/app/content/sagas/browserAction.js
+++ b/src/app/content/sagas/browserAction.js
@@ -1,9 +1,11 @@
-import { put, takeLatest } from 'redux-saga/effects';
+import { put, takeLatest, select } from 'redux-saga/effects';
 import { BROWSER_ACTION_CLICKED } from '../../constants/browser/action';
-import { open } from '../actions/ui';
+import { open, close } from '../actions/ui';
+import { isOpen as isNotificationOpen } from '../selectors';
 
 export function* browserActionClickedSaga() {
-  yield put(open());
+  const isOpen = yield select(isNotificationOpen);
+  yield put(isOpen ? close() : open());
 }
 
 export default function* backgroundRootSaga() {


### PR DESCRIPTION
When notification is opened, and user clicked on the toolbar icon, the notification was refreshed but not closed. 

With this change, the notification is closed if already opened. 