### PR TITLE
fix: wait for tab to complete before dispatching

### DIFF
--- a/src/app/background/store/listenTabs.js
+++ b/src/app/background/store/listenTabs.js
@@ -6,9 +6,9 @@ export const onTabCreated = store => ({ id, url }) => {
   store.dispatch(tabCreated(id, { url }));
 };
 
-export const onTabUpdated = store => (id, { status, url: newUrl }, { url }) => {
-  if (status === 'loading') {
-    const matchingUrl = newUrl || url; // handle reloading
+export const onTabUpdated = store => (id, changeInfo, tab) => {
+  if (changeInfo.status === 'complete') {
+    const matchingUrl = changeInfo.url || tab.url; // handle reloading
 
     store.dispatch(tabUpdated(id, { url: matchingUrl }));
   }


### PR DESCRIPTION
This fixes this "double iframe" issue on Liligo ... but I still have to check that it doesn't break anything elsewhere ...