### PR TITLE
fix(notification): fix click outside

### DIFF
--- a/src/app/content/index.ts
+++ b/src/app/content/index.ts
@@ -1,8 +1,8 @@
 if (!(window as CustomWindow).__LMEM__CONTENT_SCRIPT_INJECTED__) {
   require('typeface-lato');
   require('typeface-sedgwick-ave');
-  const store = require('./store');
-  const externalClickHandler = require('./externalClickHandler');
+  const store = require('./store').default;
+  const externalClickHandler = require('./externalClickHandler').default;
   const handleExternalClick = externalClickHandler(store);
 
   window.addEventListener('load', () => {


### PR DESCRIPTION
When changed from `import` to `require`, we forgot to get `default` which is not handled transparently when `export default` is used in conjunction with `require`

Content script is actually crashing on boot-up :-/