### PR TITLE
feat(sentry): condition Sentry logging and version declaring to yarn release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
   "scripts": {
     "start": "webpack --watch --progress --hot --env.hmr --mode=development --env.build=dev",
     "build:staging": "webpack --mode=production --env.build=staging",
+    "release:staging": "webpack --mode=production --env.build=staging --env.sentry",
     "build:firefox": "webpack --mode=production --env.build=firefox",
     "build:chromium": "webpack --mode=production --env.build=chromium",
     "build:production": "yarn build:chromium && yarn build:firefox",
+    "release:production": "yarn build:chromium --env.sentry && yarn build:firefox --env.sentry",
     "build": "yarn build:staging && yarn build:production",
+    "release": "yarn release:staging && yarn release:production",
     "clean": "rm -rf build",
     "test": "LMEM_BACKEND_ORIGIN='' NODE_ENV=test ts-mocha --paths test/app/*.ts test/app/**/*.ts",
     "lint": "yarn lint:ts && yarn lint:css",

--- a/src/app/background/index.ts
+++ b/src/app/background/index.ts
@@ -7,21 +7,15 @@ import {
   refreshMatchingContextsEvery
 } from 'app/actions/kraftBackend';
 import onInstalled from 'app/actions/install';
-import { init, configureScope } from '@sentry/browser';
+import { configureSentryScope, initSentry } from '../utils/sentry';
 import updateDraftRecommendations from 'app/actions/updateDraftRecommendations';
 import { getInstallationDetails } from './selectors/prefs';
 import { store } from './store';
 import fetchContentScript from './services/fetchContentScript';
 import { BackgroundState } from './reducers';
-import { version } from 'app/../../package.json';
 
-init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  release: `${version}-${process.env.BUILD}`,
-});
-
-configureScope((scope) => {
+initSentry();
+configureSentryScope(scope => {
   scope.setTag('context', 'background');
 });
 
@@ -50,7 +44,7 @@ if (typeof heapAppId === 'string') {
       if (heap) {
         setUninstallURL(heap.userId);
 
-        configureScope((scope) => {
+        configureSentryScope(scope => {
           scope.setUser({ id: heap.userId });
         });
       }

--- a/src/app/content/App/index.tsx
+++ b/src/app/content/App/index.tsx
@@ -3,7 +3,6 @@ import { Provider, connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { ConnectedRouter } from 'connected-react-router/immutable';
 import { ThemeProvider, StyleSheetManager } from 'styled-components';
-import { configureScope } from '@sentry/browser';
 import theme from '../../theme';
 import store, { history, State } from '../store';
 import GlobalStyle from '../GlobalStyle';
@@ -14,6 +13,7 @@ import Notice from './Notice';
 import Subscriptions from './Subscriptions';
 import Help from './Help';
 import { isOpen } from '../selectors';
+import { configureSentryScope } from '../../utils/sentry';
 
 const DELAY_BEFORE_SHOWING = process.env.NODE_ENV === 'production' ? 4000 : 10;
 
@@ -59,7 +59,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
 
   componentDidMount() {
     setTimeout(this.setLoaded, DELAY_BEFORE_SHOWING);
-    configureScope((scope) => {
+    configureSentryScope(scope => {
       scope.setTag('context', 'iframe');
     });
   }

--- a/src/app/content/index.ts
+++ b/src/app/content/index.ts
@@ -1,20 +1,13 @@
-/* eslint-disable global-require */
-import { init, configureScope } from '@sentry/browser';
-import { version } from '../../../package.json';
-
 if (!(window as CustomWindow).__LMEM__CONTENT_SCRIPT_INJECTED__) {
   require('typeface-lato');
   require('typeface-sedgwick-ave');
   require('./store');
+  const { configureSentryScope, initSentry } = require('../utils/sentry');
   (window as CustomWindow).__LMEM__CONTENT_SCRIPT_INJECTED__ = true;
 
-  init({
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.NODE_ENV,
-    release: `${version}-${process.env.BUILD}`,
-  });
+  initSentry();
 
-  configureScope((scope: any) => {
+  configureSentryScope((scope: any) => {
     scope.setTag('context', 'content');
   });
 }

--- a/src/app/utils/sentry.ts
+++ b/src/app/utils/sentry.ts
@@ -1,0 +1,19 @@
+import { init, configureScope, Scope } from '@sentry/browser';
+import { version } from '../../../package.json';
+
+export const initSentry = () => {
+  if (process.env.SENTRY_ENABLE) {
+    init({
+      dsn: process.env.SENTRY_DSN,
+      environment: process.env.NODE_ENV,
+      release: `${version}-${process.env.BUILD}`
+    });
+  }
+};
+
+type ScopeCallback = (scope: Scope) => void;
+export const configureSentryScope = (scopeCallback: ScopeCallback) => {
+  if (process.env.SENTRY_ENABLE) {
+    configureScope(scopeCallback);
+  }
+};

--- a/webpack/config.plugins.js
+++ b/webpack/config.plugins.js
@@ -12,14 +12,14 @@ const { version } = require('../package.json');
 
 const ENV = {
   dev: {
-    LMEM_BACKEND_ORIGIN: '"https://recommendations.lmem.net"',
+    LMEM_BACKEND_ORIGIN: '"https://recommendations.lmem.net"'
   },
   staging: {
     LMEM_BACKEND_ORIGIN: '"https://staging-recommendations.lmem.net"',
     UNINSTALL_ORIGIN: "'https://www.lmem.net/desinstallation'",
     HEAP_APPID: '"234457910"', // testing
     REFRESH_MC_INTERVAL: '5*60*1000',
-    SENTRY_DSN: '"https://12ed31b41955443480dbfcb5da3e3a33@sentry.io/1404898"',
+    SENTRY_DSN: '"https://12ed31b41955443480dbfcb5da3e3a33@sentry.io/1404898"'
   },
   chromium: {
     LMEM_BACKEND_ORIGIN: '"https://reco2bulle.lmem.net"',
@@ -27,14 +27,14 @@ const ENV = {
     REFRESH_MC_INTERVAL: '30*60*1000',
     ONBOARDING_ORIGIN: '"https://bienvenue.lmem.net?extensionInstalled"',
     HEAP_APPID: '"3705584166"', // production
-    SENTRY_DSN: '"https://12ed31b41955443480dbfcb5da3e3a33@sentry.io/1404898"',
+    SENTRY_DSN: '"https://12ed31b41955443480dbfcb5da3e3a33@sentry.io/1404898"'
   },
   firefox: {
     LMEM_BACKEND_ORIGIN: '"https://reco2bulle.lmem.net"',
     ONBOARDING_ORIGIN: '"https://bienvenue.lmem.net?extensionInstalled"',
     REFRESH_MC_INTERVAL: '30*60*1000',
     // No analytics with Firefox // HEAP_APPID: '"3705584166"',
-    SENTRY_DSN: '"https://12ed31b41955443480dbfcb5da3e3a33@sentry.io/1404898"',
+    SENTRY_DSN: '"https://12ed31b41955443480dbfcb5da3e3a33@sentry.io/1404898"'
   }
 };
 
@@ -57,7 +57,11 @@ module.exports = (env = {}, argv = {}, outputPath) => {
 
   const plugins = [
     new webpack.DefinePlugin({
-      'process.env': { ...ENV[env.build], BUILD: JSON.stringify(env.build) }
+      'process.env': {
+        ...ENV[env.build],
+        BUILD: JSON.stringify(env.build),
+        SENTRY_ENABLE: env.sentry ? 'true' : 'false'
+      }
     }),
     new HtmlWebpackPlugin({
       template: './views/background.pug',
@@ -71,14 +75,14 @@ module.exports = (env = {}, argv = {}, outputPath) => {
     new CopyWebpackPlugin(copyConfig)
   ];
 
-  if (env.build !== 'dev') {
+  if (env.sentry) {
     plugins.push(
       new SentryWebpackPlugin({
         include: `./build/${env.build}/js`,
         ignore: ['test.*.js*'],
-        release: `${version}-${env.build}`,
+        release: `${version}-${env.build}`
       })
-    )
+    );
   }
 
   if (!env.hmr) {


### PR DESCRIPTION
Follow-up to #269 : Proposal so that we : 
 - send versioned app files to Sentry
 - Log errors
*only* when using `yarn release` (or `yarn release:production|staging`) script. 

Completely ignores Sentry feature otherwise