### PR TITLE
Chore/add sentry to semantic release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,32 +2,29 @@ const release = Object.freeze({
   analyzeCommits: {
     preset: 'angular',
     parserOpts: {
-      noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'MAJOR RELEASE'],
-    },
+      noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'MAJOR RELEASE']
+    }
   },
   verifyConditions: [
     '@semantic-release/changelog',
     '@semantic-release/git',
     '@semantic-release/github',
-    'semantic-release-chrome',
+    'semantic-release-chrome'
   ],
   prepare: [
     '@semantic-release/changelog',
     {
       path: '@semantic-release/exec',
-      cmd: 'sed -i \'s/"version":\\s*"${lastRelease.version}"/"version": "${nextRelease.version}"/\' package.json && ' +
-        'npm run build:production'
+      cmd:
+        'sed -i \'s/"version":\\s*"${lastRelease.version}"/"version": "${nextRelease.version}"/\' package.json && ' +
+        'yarn run release:production'
     },
     {
       path: '@semantic-release/git',
-      assets: [
-        'package.json',
-        'yarn.lock',
-        'CHANGELOG.md',
-        'manifest/base.js'
-      ],
-      message: 'chore: release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-    },
+      assets: ['package.json', 'yarn.lock', 'CHANGELOG.md', 'manifest/base.js'],
+      message:
+        'chore: release ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+    }
   ],
   publish: [
     {
@@ -40,16 +37,16 @@ const release = Object.freeze({
         {
           path: 'build/lmem-v*-chromium.zip',
           label: 'Chromium Package'
-        },
-      ],
-    },
+        }
+      ]
+    }
     //FIXME: semantic-release-chrome does not take globs on assets pathnames
     //{
     //  path: 'semantic-release-chrome',
     //  asset: 'build/lmem-v*-chromium.zip',
     //  extensionId: 'fpjlnlnbacohacebkadbbjebbipcknbg',
     //},
-  ],
+  ]
 });
 
 module.exports = release;


### PR DESCRIPTION
Use `yarn release:production` instead of `npm run build:production`