### PR TITLE
fix(iframe): hide iframe when content closed

### DIFF
--- a/src/app/content/extensionIframe.ts
+++ b/src/app/content/extensionIframe.ts
@@ -25,16 +25,20 @@ export const append = (iframe: HTMLIFrameElement): Promise<Document | null> =>
     document.body.appendChild(iframe);
   });
 
-export const remove = (): void => {
-  const iframe = document.getElementById('lmemFrame');
-  if (iframe) {
-    iframe.remove();
+export const show = () => {
+  const frame = document.querySelector('#lmemFrame');
+  if (frame) {
+    (frame as HTMLIFrameElement).style.removeProperty('display');
   }
 };
 
-export const setImportant = () => {
+export const hide = () => {
   const frame = document.querySelector('#lmemFrame');
   if (frame) {
-    (frame as HTMLIFrameElement).style.setProperty('display', '', 'important');
+    (frame as HTMLIFrameElement).style.setProperty(
+      'display',
+      'none',
+      'important'
+    );
   }
 };

--- a/src/app/content/sagas/ui.tsx
+++ b/src/app/content/sagas/ui.tsx
@@ -10,15 +10,12 @@ import {
   hasUnreadNotices
 } from '../selectors';
 import { CLOSE, OPEN, NOTICES_FOUND } from '../../constants/ActionTypes';
-import {
-  append,
-  create,
-  setImportant as setFrameImportant
-} from '../extensionIframe';
+import { append, create, hide, show } from '../extensionIframe';
 import theme from '../../theme';
 import App from '../App';
 
 const iframe = create(theme.iframe.style);
+let contentDocument: Document;
 
 export function* openSaga() {
   const isOpen = yield select(isNotificationOpen);
@@ -30,15 +27,15 @@ export function* openSaga() {
       yield put(push('/'));
     }
 
-    if (isMounted) {
-      setFrameImportant();
+    if (isMounted && contentDocument.visibilityState === 'visible') {
+      show();
     } else {
-      const contentDocument = yield call(append, iframe);
+      contentDocument = yield call(append, iframe);
       const root = document.createElement('div');
       contentDocument.body.appendChild(root);
-      const show = () =>
+      const renderAppToIframe = () =>
         render(<App contentDocument={contentDocument} />, root);
-      yield call(show);
+      yield call(renderAppToIframe);
     }
 
     yield put(opened());
@@ -48,7 +45,7 @@ export function* openSaga() {
 export function* closeSaga() {
   const isOpen = yield select(isNotificationOpen);
   if (isOpen) {
-    setFrameImportant();
+    hide();
     yield put(closed());
   }
 }


### PR DESCRIPTION
React content was rendered to `null` when application state was "Closed", but Iframe was still there, thus ghosting the website with a invisible-but-impossible-to-interact-zone