### PR TITLE
fix(firefox): catch sentry init error in content script

### DIFF
--- a/src/app/content/index.ts
+++ b/src/app/content/index.ts
@@ -1,7 +1,11 @@
 if (!(window as CustomWindow).__LMEM__CONTENT_SCRIPT_INJECTED__) {
   const { configureSentryScope, initSentry } = require('../utils/sentry');
 
-  initSentry();
+  try {
+    initSentry();
+  } catch (error) {
+    console.warn('Could not init Sentry in contentScript', error);
+  }
   configureSentryScope((scope: any) => {
     scope.setTag('context', 'content');
   });


### PR DESCRIPTION
![image (4)](https://user-images.githubusercontent.com/3037833/59203506-04e9c180-8b9f-11e9-86d6-29c5da344b6e.png)
