### PR TITLE
chore(storybook): disable browser auto open on storybook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:ts": "tslint -p .",
     "lint:css": "stylelint './src/**/*.js'",
     "analyse": "babel-node ./node_modules/webpack/bin/webpack --optimize-minimize --mode production --config webpack/chromium.config.js --profile --json > stats.json",
-    "storybook": "start-storybook -p 6007 -c .storybook",
+    "storybook": "start-storybook --ci -p 6007 -c .storybook",
     "build-storybook": "build-storybook"
   },
   "husky": {


### PR DESCRIPTION
I personally hate that Storybook opens my default browser automatically when I run `yarn storybook`, especially when I restart it and the UI is already open in another browser ...

This stops that. 

If you agree with the annoyance :-)