### PR TITLE
fix(fetchMatchingContexts): catch network error

### DIFF
--- a/src/app/actions/kraftBackend.ts
+++ b/src/app/actions/kraftBackend.ts
@@ -15,11 +15,28 @@ export const receivedMatchingContexts = (
   meta: { tracked: false }
 });
 
+export interface ReceivedMatchingContextsFailureAction extends BaseAction {
+  type: 'api/UPDATE_MATCHING_CONTEXTS_FAILURE';
+  payload: { error: Error };
+  meta: { tracked: false };
+}
+export const receivedMatchingContextsFailure = (
+  error: Error
+): ReceivedMatchingContextsFailureAction => ({
+  type: 'api/UPDATE_MATCHING_CONTEXTS_FAILURE',
+  payload: { error },
+  meta: { tracked: false }
+});
+
 export function dispatchInitialStateFromBackend() {
   return (dispatch: Dispatch) =>
-    fetchMatchingContexts().then((matchingContexts: MatchingContext[]) =>
-      dispatch(receivedMatchingContexts(matchingContexts))
-    );
+    fetchMatchingContexts()
+      .then((matchingContexts: MatchingContext[]) =>
+        dispatch(receivedMatchingContexts(matchingContexts))
+      )
+      .catch((error: Error) =>
+        dispatch(receivedMatchingContextsFailure(error))
+      );
 }
 
 export interface RefreshMatchingContextsAction extends BaseAction {

--- a/src/app/background/sagas/matchingContexts.ts
+++ b/src/app/background/sagas/matchingContexts.ts
@@ -2,12 +2,18 @@ import { put, takeLatest, call } from 'redux-saga/effects';
 import fetchMatchingContexts from '../../../api/fetchMatchingContexts';
 import { REFRESH_MATCHING_CONTEXTS } from '../../constants/ActionTypes';
 
-import { receivedMatchingContexts } from 'app/actions/kraftBackend';
+import {
+  receivedMatchingContexts,
+  receivedMatchingContextsFailure
+} from 'app/actions/kraftBackend';
 
 export function* refreshMatchingContextsSaga() {
-  const matchingContexts = yield call(fetchMatchingContexts);
-
-  yield put(receivedMatchingContexts(matchingContexts));
+  try {
+    const matchingContexts = yield call(fetchMatchingContexts);
+    yield put(receivedMatchingContexts(matchingContexts));
+  } catch (e) {
+    yield put(receivedMatchingContextsFailure(e));
+  }
 }
 
 export default function* tabRootSaga() {


### PR DESCRIPTION
Redux-Saga now recovers from network failures while fetching matching contexts. (ref #257)


**Before merging**, please note this PR is to be merged into `master` but should never end up into `develop` (since @lutangar already addressed the issue in #282)
