### PR TITLE
refactor: clarify display/unfold/read notions

### DIFF
--- a/src/app/actions/index.ts
+++ b/src/app/actions/index.ts
@@ -25,8 +25,9 @@ import { InstalledDetailsAction } from './filters';
 import { CloseAction, ClosedAction, OpenAction, OpenedAction } from './ui';
 import {
   FeedbackOnNoticeAction,
+  MarkNoticeReadAction,
   NoticesFoundAction,
-  MarkNoticeReadAction
+  UnfoldNoticeAction
 } from './notices';
 import {
   ContributionSubmissionFailed,
@@ -158,6 +159,7 @@ export type AppAction =
   | ClosedAction
   | NoticesFoundAction
   | FeedbackOnNoticeAction
+  | UnfoldNoticeAction
   | MarkNoticeReadAction
   | SetUITitleAction
   | RemoveUITitleAction

--- a/src/app/actions/notices.ts
+++ b/src/app/actions/notices.ts
@@ -98,6 +98,17 @@ export const undislikeNotice = (id: number): FeedbackOnNoticeAction => ({
   meta: { sendToBackground: true }
 });
 
+export interface UnfoldNoticeAction extends BaseAction {
+  type: 'UNFOLD_NOTICE';
+  payload: number;
+}
+
+export const unfoldNotice = (id: number): UnfoldNoticeAction => ({
+  type: 'UNFOLD_NOTICE',
+  payload: id,
+  meta: { sendToBackground: true }
+});
+
 export interface MarkNoticeReadAction extends BaseAction {
   type: 'MARK_NOTICE_READ';
   payload: number;
@@ -105,8 +116,7 @@ export interface MarkNoticeReadAction extends BaseAction {
 
 export const markNoticeRead = (id: number): MarkNoticeReadAction => ({
   type: 'MARK_NOTICE_READ',
-  payload: id,
-  meta: { sendToBackground: true }
+  payload: id
 });
 
 export interface NoticesUpdatedAction extends TabAction {

--- a/src/app/actions/ui.ts
+++ b/src/app/actions/ui.ts
@@ -1,5 +1,5 @@
 import { BaseAction, ErrorAction } from '.';
-import { CloseCause } from '../lmem/ui';
+import { CloseCause } from 'app/lmem/ui';
 
 export interface OpenAction extends BaseAction {
   type: 'OPEN';

--- a/src/app/background/reducers/prefs.reducer.ts
+++ b/src/app/background/reducers/prefs.reducer.ts
@@ -8,7 +8,7 @@ export interface PrefsState {
   dismissedNotices: number[];
   likedNotices: number[];
   dislikedNotices: number[];
-  markedReadNotices: number[];
+  readNotices: number[];
 }
 
 const initialPrefs: PrefsState = {
@@ -16,7 +16,7 @@ const initialPrefs: PrefsState = {
   dismissedNotices: [],
   likedNotices: [],
   dislikedNotices: [],
-  markedReadNotices: []
+  readNotices: []
 };
 
 function prefsReducer(state: PrefsState = initialPrefs, action: AppAction) {
@@ -71,12 +71,10 @@ function prefsReducer(state: PrefsState = initialPrefs, action: AppAction) {
       }
       return state;
 
-    case 'MARK_NOTICE_READ':
+    case 'UNFOLD_NOTICE':
       return {
         ...state,
-        markedReadNotices: R.uniq(
-          R.concat(state.markedReadNotices, [action.payload])
-        )
+        readNotices: R.uniq(R.concat(state.readNotices, [action.payload]))
       };
 
     default:

--- a/src/app/background/selectors/prefs.ts
+++ b/src/app/background/selectors/prefs.ts
@@ -16,8 +16,7 @@ export const getLiked = (state: BackgroundState) =>
   getPrefs(state).likedNotices;
 export const getDisliked = (state: BackgroundState) =>
   getPrefs(state).dislikedNotices;
-export const getMarkedRead = (state: BackgroundState) =>
-  getPrefs(state).markedReadNotices;
+export const getRead = (state: BackgroundState) => getPrefs(state).readNotices;
 
 export const getInitialContent = (state: BackgroundState) => ({
   installationDetails: getInstallationDetails(state)
@@ -27,7 +26,7 @@ export const getAddStateToNotice = (state: BackgroundState) => {
   const dismissed = getDismissed(state);
   const liked = getLiked(state);
   const disliked = getDisliked(state);
-  const markedRead = getMarkedRead(state);
+  const read = getRead(state);
 
   return (notice: Notice): StatefulNotice => ({
     ...notice,
@@ -35,7 +34,7 @@ export const getAddStateToNotice = (state: BackgroundState) => {
       dismissed: dismissed.includes(notice.id),
       liked: liked.includes(notice.id),
       disliked: disliked.includes(notice.id),
-      markedRead: markedRead.includes(notice.id)
+      read: read.includes(notice.id)
     }
   });
 };

--- a/src/app/background/selectors/subscriptions.selectors.spec.ts
+++ b/src/app/background/selectors/subscriptions.selectors.spec.ts
@@ -24,7 +24,7 @@ describe('background > selectors > getContributorsWithSubscriptionState', () => 
         likedNotices: [],
         dislikedNotices: [],
         dismissedNotices: [],
-        markedReadNotices: []
+        readNotices: []
       },
       resources: {
         matchingContexts: [],

--- a/src/app/background/store/migrations/5.2019-09-12.spec.ts
+++ b/src/app/background/store/migrations/5.2019-09-12.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { migration5 } from './5.2019-09-12';
+import { StateV4 } from './StateV4';
+
+describe('migrations/5', () => {
+  describe('if previous state has `markedReadNotices` key', () => {
+    const storeV4: StateV4 = {
+      prefs: {
+        installationDetails: {
+          datetime: new Date(),
+          version: '1'
+        },
+        likedNotices: [],
+        dislikedNotices: [],
+        dismissedNotices: [],
+        markedReadNotices: [1, 42]
+      }
+    };
+
+    const migratedStore = migration5(storeV4);
+
+    it('removes the `readNotices` keys', () => {
+      expect(migratedStore).to.not.have.nested.property(
+        'prefs.markedReadNotices'
+      );
+    });
+    it('keeps old `markedReadNotices` data in `readNotices` key', () => {
+      expect(migratedStore)
+        .to.have.nested.property('prefs.readNotices')
+        .that.eql([1, 42]);
+    });
+  });
+  describe("if previous state doesn't have `markedReadNotices` key", () => {
+    const storeV4: StateV4 = {
+      prefs: {
+        installationDetails: {
+          datetime: new Date(),
+          version: '1'
+        },
+        likedNotices: [],
+        dislikedNotices: [],
+        dismissedNotices: []
+      }
+    };
+
+    const migratedStore = migration5(storeV4);
+
+    it('does nothing', () => {
+      expect(migratedStore).to.eql(storeV4);
+    });
+  });
+});

--- a/src/app/background/store/migrations/5.2019-09-12.ts
+++ b/src/app/background/store/migrations/5.2019-09-12.ts
@@ -1,0 +1,16 @@
+import { PersistedState } from 'redux-persist/es/types';
+import { PersistedBackgroundState } from '../../reducers';
+import * as RA from 'ramda-adjunct';
+import { StateV4 } from './StateV4';
+import { overPrefs } from './helpers';
+
+export const migration5 = (
+  persistedState: PersistedState
+): PersistedBackgroundState => {
+  const previousState = persistedState as StateV4;
+
+  return (overPrefs(
+    RA.renameKeys({ markedReadNotices: 'readNotices' }),
+    previousState
+  ) as unknown) as PersistedBackgroundState; // Ramda-adjunct TypeScript definition wrongfuly assumes renameKeys input and output is the same type. There is room for improvement
+};

--- a/src/app/background/store/migrations/StateV4.ts
+++ b/src/app/background/store/migrations/StateV4.ts
@@ -1,0 +1,14 @@
+import { InstallationDetails } from '../../../lmem/installation';
+import { PersistedState } from 'redux-persist/es/types';
+
+interface StateV4Prefs {
+  installationDetails: InstallationDetails;
+  dismissedNotices: number[];
+  likedNotices: number[];
+  dislikedNotices: number[];
+  markedReadNotices?: number[];
+}
+
+export interface StateV4 extends PersistedState {
+  prefs: StateV4Prefs;
+}

--- a/src/app/background/store/migrations/index.ts
+++ b/src/app/background/store/migrations/index.ts
@@ -4,12 +4,14 @@ import { migration1 } from './1.2017-01-26';
 import { migration2 } from './2.2019-02-11';
 import { migration3 } from './3.2019-03';
 import { migration4 } from './4.2019-08-28';
+import { migration5 } from './5.2019-09-12';
 
 const migrations: MigrationManifest = {
   1: migration1, // 26-01-2017
   2: migration2, // 2019-02-11
   3: migration3, // March 2019 - Typescript migration
-  4: migration4 // August 2019 - rename readNotices to markedReadNotices
+  4: migration4, // August 2019 - rename readNotices to markedReadNotices
+  5: migration5 // Septembre 2019 - rename markedReadNotices back to readNotices
 };
 
 export const migrate = createMigrate(migrations, {

--- a/src/app/content/App/Notice/Details/withConnect.ts
+++ b/src/app/content/App/Notice/Details/withConnect.ts
@@ -6,7 +6,7 @@ import {
   dislikeNotice,
   confirmDislikeNotice,
   undislikeNotice,
-  markNoticeRead,
+  unfoldNotice,
   resourceLinkClicked
 } from 'app/actions/notices';
 import { ContentState } from '../../../store';
@@ -41,7 +41,7 @@ const mapDispatchToProps: DetailsDispatchProps = {
   dislike: dislikeNotice,
   confirmDislike: confirmDislikeNotice,
   undislike: undislikeNotice,
-  view: markNoticeRead,
+  view: unfoldNotice,
   followSource: resourceLinkClicked
 };
 

--- a/src/app/content/App/Notice/List/List.stories.tsx
+++ b/src/app/content/App/Notice/List/List.stories.tsx
@@ -80,7 +80,7 @@ storiesOf('screens/Notice/List', module)
           message: `<p>${text('message(1)', firstMessage, 'first')}</p>`
         }),
         generateStatefulNotice({
-          markedRead: true,
+          read: true,
           dismissed: boolean('dismissed(2)', false, 'second'),
           intention: select(
             'intention(2)',

--- a/src/app/content/sagas/ui.tsx
+++ b/src/app/content/sagas/ui.tsx
@@ -14,7 +14,7 @@ import {
   isOpen as isNotificationOpen,
   isMounted as isNotificationMounted,
   getPathname,
-  hasMarkedUnreadNotices
+  hasUnreadNotices
 } from '../selectors';
 import { CLOSE, OPEN, NOTICES_FOUND } from '../../constants/ActionTypes';
 import { append, create, hide, show } from '../extensionIframe';
@@ -68,7 +68,7 @@ export function* closeSaga(closeAction: CloseAction) {
 }
 
 export function* noticesFoundSaga() {
-  const shouldOpen = yield select(hasMarkedUnreadNotices);
+  const shouldOpen = yield select(hasUnreadNotices);
   if (shouldOpen) {
     yield put(open());
   }

--- a/src/app/content/selectors/index.ts
+++ b/src/app/content/selectors/index.ts
@@ -10,7 +10,7 @@ import {
 import * as R from 'ramda';
 import {
   getNotice,
-  isMarkedUnread,
+  isUnread,
   shouldNoticeBeShown,
   Contribution
 } from 'app/lmem/notice';
@@ -26,11 +26,11 @@ export const getNoticesToDisplay = createSelector(
   notices => notices.filter(shouldNoticeBeShown)
 );
 
-export const getMarkedUnreadNotices = (state: ContentState) =>
-  getNoticesToDisplay(state).filter(isMarkedUnread);
+export const getUnreadNotices = (state: ContentState) =>
+  getNoticesToDisplay(state).filter(isUnread);
 
-export const hasMarkedUnreadNotices = (state: ContentState) =>
-  getMarkedUnreadNotices(state).length > 0;
+export const hasUnreadNotices = (state: ContentState) =>
+  getUnreadNotices(state).length > 0;
 
 export const getNoticeById = (
   state: ContentState,

--- a/src/app/lmem/badge.ts
+++ b/src/app/lmem/badge.ts
@@ -1,9 +1,9 @@
-import { StatefulNotice, isMarkedUnread } from './notice';
+import { StatefulNotice, isUnread } from './notice';
 
 export interface BadgeTheme {
   backgroundColor: {
-    markedRead: string;
-    markedUnread: string;
+    hasAllNoticesRead: string;
+    hasUnreadNotices: string;
   };
 }
 
@@ -25,21 +25,21 @@ export const updateBadge = (
   tabId?: number
 ): void => {
   if (notices.length > 0) {
-    const markedUnreadNotices = notices.filter(isMarkedUnread);
+    const unreadNotices = notices.filter(isUnread);
     const { backgroundColor } = badgeTheme;
 
     chrome.browserAction.setBadgeText({
       text:
-        markedUnreadNotices.length > 0
-          ? markedUnreadNotices.length.toString()
+        unreadNotices.length > 0
+          ? unreadNotices.length.toString()
           : notices.length.toString(),
       tabId
     });
     chrome.browserAction.setBadgeBackgroundColor({
       color:
-        markedUnreadNotices.length > 0
-          ? backgroundColor.markedUnread
-          : backgroundColor.markedRead,
+        unreadNotices.length > 0
+          ? backgroundColor.hasUnreadNotices
+          : backgroundColor.hasAllNoticesRead,
       tabId
     });
   } else {

--- a/src/app/lmem/notice.ts
+++ b/src/app/lmem/notice.ts
@@ -25,7 +25,7 @@ export interface Contribution {
 }
 
 export interface NoticeState {
-  markedRead: boolean;
+  read: boolean;
   liked: boolean;
   justLiked?: boolean;
   disliked: boolean;
@@ -128,7 +128,7 @@ export const markNoticeRead = (notice: StatefulNotice): StatefulNotice => ({
   ...notice,
   state: {
     ...notice.state,
-    markedRead: true
+    read: true
   }
 });
 
@@ -169,6 +169,6 @@ export const shouldNoticeBeShown = (notice: StatefulNotice): boolean =>
     (!notice.state.disliked || notice.state.justDisliked)) ||
   false;
 
-export const isMarkedRead = (notice: StatefulNotice) => notice.state.markedRead;
+export const isRead = (notice: StatefulNotice) => notice.state.read;
 
-export const isMarkedUnread = (notice: StatefulNotice) => !isMarkedRead(notice);
+export const isUnread = (notice: StatefulNotice) => !isRead(notice);

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -104,8 +104,8 @@ export const theme: Theme = {
   // badge background colors
   badge: {
     backgroundColor: {
-      markedRead: '#9DA1A7',
-      markedUnread: '#DB0D0D'
+      hasAllNoticesRead: '#9DA1A7',
+      hasUnreadNotices: '#DB0D0D'
     }
   },
 

--- a/src/components/organisms/Notice/Content.tsx
+++ b/src/components/organisms/Notice/Content.tsx
@@ -6,9 +6,9 @@ import { LocationDescriptor } from 'history';
 interface ContentProps {
   to?: LocationDescriptor;
   children: ReactNode;
-  markedRead: boolean;
+  isRead: boolean;
 }
-const Content = ({ to, markedRead, ...props }: ContentProps) => {
+const Content = ({ to, isRead, ...props }: ContentProps) => {
   if (to) {
     return <Link to={to} {...props} />;
   }
@@ -27,9 +27,9 @@ export default styled(Content)`
   margin-right: 11px;
   margin-left: 5px;
   text-decoration: none;
-  background-color: ${props => (props.markedRead ? 'transparent' : '#fff')};
+  background-color: ${props => (props.isRead ? 'transparent' : '#fff')};
   border-radius: 15px;
-  border: 2px solid ${props => (props.markedRead ? '#fff' : 'transparent')};
+  border: 2px solid ${props => (props.isRead ? '#fff' : 'transparent')};
 
   &,
   p {

--- a/src/components/organisms/Notice/Notice.stories.tsx
+++ b/src/components/organisms/Notice/Notice.stories.tsx
@@ -97,11 +97,11 @@ storiesOf('organisms/Notice', module)
       })}
     />
   ))
-  .add('Marked read', () => (
+  .add('Read', () => (
     <Notice
       {...commonProps}
       notice={generateStatefulNotice({
-        markedRead: true,
+        read: true,
         intention: select('intention', intentions, 'approval'),
         contributor: text('contributor', defaultContributorName),
         message: `<p>${text('message', defaultMessage)}</p>`

--- a/src/components/organisms/Notice/Notice.tsx
+++ b/src/components/organisms/Notice/Notice.tsx
@@ -60,10 +60,6 @@ export default class Notice extends PureComponent<Props, CountDownState> {
   }
 
   static defaultProps = {
-    intention: 'Other',
-    dismissed: false,
-    disliked: false,
-    markedRead: false,
     truncateTitleAt: Title.defaultProps.numberOfCharacters
   };
 
@@ -118,7 +114,7 @@ export default class Notice extends PureComponent<Props, CountDownState> {
         intention,
         message,
         contributor,
-        state: { dismissed, disliked, markedRead }
+        state: { dismissed, disliked, read }
       },
       truncateTitleAt,
       style
@@ -131,7 +127,7 @@ export default class Notice extends PureComponent<Props, CountDownState> {
         {!dismissed && !disliked && <DeleteButton onClick={this.onDismiss} />}
         <Content
           to={dismissed || intervalID ? undefined : `notices/details/${id}`}
-          markedRead={markedRead}
+          isRead={read}
         >
           {(dismissed || disliked) && intervalID ? (
             <>

--- a/test/app/actions.ts
+++ b/test/app/actions.ts
@@ -37,7 +37,7 @@ const notice: StatefulNotice = {
     liked: false,
     disliked: false,
     dismissed: false,
-    markedRead: false
+    read: false
   },
   created: new Date(),
   modified: new Date()
@@ -87,7 +87,7 @@ describe('background actions', function() {
         dismissed: true,
         liked: false,
         disliked: false,
-        markedRead: false
+        read: false
       }
     };
     const action = noticeIgnored(dismissedNotice, trigger);
@@ -106,7 +106,7 @@ describe('background actions', function() {
         dismissed: false,
         liked: false,
         disliked: true,
-        markedRead: false
+        read: false
       }
     };
     const action = noticeIgnored(dislikedNotice, trigger);

--- a/test/app/content/actions.ts
+++ b/test/app/content/actions.ts
@@ -22,7 +22,7 @@ const notice1: StatefulNotice = {
   contributor: { id: 1, name: 'Jalil', contributions: 42 },
   visibility: 'public',
   ratings: { dislikes: 0, likes: 0 },
-  state: { disliked: false, dismissed: false, liked: false, markedRead: false },
+  state: { disliked: false, dismissed: false, liked: false, read: false },
   created: new Date(),
   modified: new Date()
 };

--- a/test/app/middlewares/analytics.ts
+++ b/test/app/middlewares/analytics.ts
@@ -5,7 +5,7 @@ import { Action } from 'redux';
 import middleware from '../../../src/app/background/middlewares/analytics';
 import { close } from '../../../src/app/actions/ui';
 import {
-  markNoticeRead,
+  unfoldNotice,
   resourceLinkClicked
 } from '../../../src/app/actions/notices';
 import { CloseCause } from '../../../src/app/lmem/ui';
@@ -60,7 +60,7 @@ describe('Analytics middleware', () => {
 
   it('tracks read notice action', () => {
     const { track, invoke } = create();
-    const action = markNoticeRead(1);
+    const action = unfoldNotice(1);
     invoke(action);
     expect(track).to.have.been.calledWith(action);
   });

--- a/test/app/reducers.ts
+++ b/test/app/reducers.ts
@@ -9,7 +9,7 @@ import {
   dislikeNotice,
   undislikeNotice,
   undismissNotice,
-  markNoticeRead
+  unfoldNotice
 } from '../../src/app/actions/notices';
 import { MatchingContext } from '../../src/app/lmem/matchingContext';
 
@@ -24,7 +24,7 @@ describe('prefsReducer reducer', function() {
         dismissedNotices: [],
         likedNotices: [],
         dislikedNotices: [],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
@@ -41,7 +41,7 @@ describe('prefsReducer reducer', function() {
         dismissedNotices: [],
         likedNotices: [],
         dislikedNotices: [],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
@@ -58,7 +58,7 @@ describe('prefsReducer reducer', function() {
         dismissedNotices: [],
         likedNotices: [],
         dislikedNotices: [],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
@@ -75,7 +75,7 @@ describe('prefsReducer reducer', function() {
         dismissedNotices: [42],
         likedNotices: [],
         dislikedNotices: [],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
@@ -92,7 +92,7 @@ describe('prefsReducer reducer', function() {
         dismissedNotices: [],
         likedNotices: [42],
         dislikedNotices: [],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
@@ -109,7 +109,7 @@ describe('prefsReducer reducer', function() {
         dismissedNotices: [],
         likedNotices: [],
         dislikedNotices: [42],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
@@ -119,20 +119,20 @@ describe('prefsReducer reducer', function() {
   });
 
   it('read notice', () => {
-    const action = markNoticeRead(42);
+    const action = unfoldNotice(42);
 
     const nextState = prefsReducer(
       {
         dismissedNotices: [],
         likedNotices: [],
         dislikedNotices: [],
-        markedReadNotices: [],
+        readNotices: [],
         installationDetails: { version: '0.1' }
       },
       action
     );
 
-    expect(nextState.markedReadNotices).to.have.lengthOf(1);
-    expect(nextState.markedReadNotices[0]).to.equal(42);
+    expect(nextState.readNotices).to.have.lengthOf(1);
+    expect(nextState.readNotices[0]).to.equal(42);
   });
 });

--- a/test/fakers/generateNotice.ts
+++ b/test/fakers/generateNotice.ts
@@ -20,7 +20,7 @@ interface Options {
   liked?: boolean;
   disliked?: boolean;
   dismissed?: boolean;
-  markedRead?: boolean;
+  read?: boolean;
   withSource?: boolean;
 }
 
@@ -41,7 +41,7 @@ export const generateStatefulNotice = ({
   liked,
   disliked,
   dismissed,
-  markedRead,
+  read,
   withSource = true
 }: Options = {}): StatefulNotice => ({
   id: Math.random() * 1000,
@@ -66,7 +66,7 @@ export const generateStatefulNotice = ({
     liked: Boolean(liked),
     dismissed: Boolean(dismissed),
     disliked: Boolean(disliked),
-    markedRead: Boolean(markedRead)
+    read: Boolean(read)
   }
 });
 
@@ -95,7 +95,7 @@ export const generateStatefulNoticeVariant = (
     liked,
     disliked,
     dismissed,
-    markedRead,
+    read,
     withSource = true
   }: Options
 ): StatefulNotice => {
@@ -125,7 +125,7 @@ export const generateStatefulNoticeVariant = (
     assocIfGiven<NoticeState, 'liked'>('liked', liked),
     assocIfGiven<NoticeState, 'disliked'>('disliked', disliked),
     assocIfGiven<NoticeState, 'dismissed'>('dismissed', dismissed),
-    assocIfGiven<NoticeState, 'markedRead'>('markedRead', markedRead)
+    assocIfGiven<NoticeState, 'read'>('read', read)
   )(notice.state);
 
   return R.pipe(


### PR DESCRIPTION
This is an attempt to clarify and to align on product language about the `display`, `unfold` and `read` terms. 

What has been applied in this PR : 

- `display` : Means that a notice has been shown in the notification popin, in the `list` (or in `details` if we later permit direct access). This is an event. A notice can be displayed multiple times. 
- `unfold` : Means that a notice has been shown in `details` screen. This is an event. A notice can be unfolded multiple times. 
- `read` : Means that a notice has been read. The notice is then shown grayed out. This is not an event. 
- `mark read` : Action of changing the state of a notice to `read`. This currently can be because of multiple causes : it has been `unfolded`, or the notification popin has been `closed`. This is an event. A notice should only be marked read once (for now). 