### PR TITLE
chore: disable ESLint Prettier checking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,8 +21,6 @@
   "extends": [
     "plugin:@typescript-eslint/recommended",
     "prettier/@typescript-eslint",
-    "plugin:prettier/recommended",
-    "prettier-standard/prettier-file",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended"
   ],


### PR DESCRIPTION
I think it's useless for ESLint to check that we're missing a line break according to Prettier, since Pretter is already working in our IDEs on save, and also as a Git hook just in case ...

Let's save some CPU and useless warnings (when editiong, before save)