### PR TITLE
feat(onboarding): cheap version of auto subscribe to lmem accounts in…

### DIFF
--- a/src/app/background/sagas/install.ts
+++ b/src/app/background/sagas/install.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from 'redux-saga';
-import { takeLatest, select, put, call, take } from 'redux-saga/effects';
+import { takeLatest, select, put, call, take, all } from 'redux-saga/effects';
 import { REHYDRATE } from 'redux-persist';
 import { captureException } from 'app/utils/sentry';
 import openOptions from 'webext/openOptionsTab';
@@ -16,6 +16,10 @@ import { areTosAccepted } from 'app/background/selectors/prefs';
 import { getInstallationDate } from 'app/background/selectors/installationDetails';
 import { InstallationDetails } from 'app/lmem/installation';
 import { version } from '../../../../package.json';
+import { subscribe } from 'app/actions';
+
+// @todo plz remove me after the beta
+const lmemContributorIds = [24, 25, 16];
 
 export function* installedSaga({
   payload: { installedDetails }
@@ -53,6 +57,7 @@ export function* installationDetailsSaga(): SagaIterator {
       yield call(chrome.browserAction.setTitle, {
         title: 'Le Même en Mieux devient Bulles'
       });
+      yield all(lmemContributorIds.map(id => put(subscribe(id))));
     }
 
     const onboardingRequired = yield select(isOnboardingRequired);


### PR DESCRIPTION
… production

The correct solutions wouold be an env variable, with validation at build time, and transformations to an array, to be used in the install saga. (Because these ids only make sense on prod env)

Since it's only for the launch, mb not worth the effort.