### PR TITLE
chore(sentry): disable CaptureConsole integration

### DIFF
--- a/src/app/utils/sentry.ts
+++ b/src/app/utils/sentry.ts
@@ -10,7 +10,7 @@ import { version } from '../../../package.json';
 import Logger from './Logger';
 
 export const initSentry = () => {
-  const blacklist = ['GlobalHandlers', 'ReportingObserver'];
+  const blacklist = ['GlobalHandlers', 'ReportingObserver', 'CaptureConsole'];
   if (process.env.SENTRY_ENABLE) {
     init({
       dsn: process.env.SENTRY_DSN,


### PR DESCRIPTION
Because we still have a lot of un-owned bugs and errors being reported : https://sentry.io/organizations/lmem/issues/1092072068/