### PR TITLE
fix(firefox): add uninstall URL for firefox too

### DIFF
--- a/webpack/config.plugins.js
+++ b/webpack/config.plugins.js
@@ -39,6 +39,7 @@ const BUILD_CONFIG = {
   },
   firefox: {
     BACKEND_ORIGIN: '"https://notices.bulles.fr/api/v3/"',
+    UNINSTALL_ORIGIN: "'https://www.bulles.fr/desinstallation'",
     REFRESH_MC_INTERVAL: '30*60*1000',
     REFRESH_CONTRIBUTORS_INTERVAL: '30*60*1000'
   }


### PR DESCRIPTION
https://trello.com/c/l4Jnx50y/207-lorsque-je-desinstalle-sur-firefox-cela-nouvre-pas-la-page-de-desintallation-donc-pas-possible-de-compter-les-desinstallations-s