### PR TITLE
fix: do not try to inject in PDF documents

### DIFF
--- a/manifest/base.js
+++ b/manifest/base.js
@@ -20,6 +20,7 @@ module.exports = Object.freeze({
   },
   content_scripts: [
     {
+      exclude_globs: ['*.pdf', '*.Pdf', '*.PDF'],
       matches: ['*://*/*'],
       js: ['js/browser-polyfill.js', 'js/content.bundle.js'],
       run_at: 'document_end'


### PR DESCRIPTION
(should) resolve https://trello.com/c/vbVDVj8g/213-ne-pas-essayer-de-matcher-ni-de-sins%C3%A9rer-dans-les-pdf