### PR TITLE
chore: add .sentryclirc example file

### DIFF
--- a/.sentryclirc.example
+++ b/.sentryclirc.example
@@ -1,0 +1,6 @@
+[defaults]
+project=web-extension
+org=lmem
+
+[auth]
+token=TOKEN


### PR DESCRIPTION
a `.sentryclirc` is required for script `yarn release` to work but no example was given.

This resolves it. 