### PR TITLE
fix(options): fix subscriptions screen live update

### DIFF
--- a/src/app/lmem/contributor.spec.ts
+++ b/src/app/lmem/contributor.spec.ts
@@ -1,25 +1,51 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
-import { contributorIsSubscribed, StatefulContributor } from './contributor';
+import {
+  contributorIsSubscribed,
+  findContributorIn,
+  StatefulContributor
+} from './contributor';
 import { generateContributor } from 'test/fakers/generateContributor';
 
-describe('lmem > contributor > contributorIsSubscribed', () => {
-  it("returns true if we're subscribed to it", () => {
-    const contributor: StatefulContributor = {
-      ...generateContributor(),
-      subscribed: true
-    };
-    expect(contributorIsSubscribed(contributor)).to.be.true;
+describe('lmem > contributor', () => {
+  describe(' contributorIsSubscribed', () => {
+    it("returns true if we're subscribed to it", () => {
+      const contributor: StatefulContributor = {
+        ...generateContributor(),
+        subscribed: true
+      };
+      expect(contributorIsSubscribed(contributor)).to.be.true;
+    });
+    it("returns false if we're subscribed to it", () => {
+      const contributor: StatefulContributor = {
+        ...generateContributor(),
+        subscribed: false
+      };
+      expect(contributorIsSubscribed(contributor)).to.be.false;
+    });
+    it("returns false if we don't know", () => {
+      const contributor: StatefulContributor = generateContributor();
+      expect(contributorIsSubscribed(contributor)).to.be.false;
+    });
   });
-  it("returns false if we're subscribed to it", () => {
-    const contributor: StatefulContributor = {
-      ...generateContributor(),
-      subscribed: false
-    };
-    expect(contributorIsSubscribed(contributor)).to.be.false;
-  });
-  it("returns false if we don't know", () => {
-    const contributor: StatefulContributor = generateContributor();
-    expect(contributorIsSubscribed(contributor)).to.be.false;
+  describe('findContributorIn', () => {
+    it('finds contributor when present in list', () => {
+      const contrib1 = generateContributor({ id: 1 });
+      const contrib2 = generateContributor({ id: 2 });
+      const contrib3 = generateContributor({ id: 3 });
+      const contrib2Copy = generateContributor({ id: 2 });
+
+      expect(
+        findContributorIn([contrib1, contrib2, contrib3])(contrib2Copy)
+      ).to.equal(contrib2);
+    });
+    it('returns null when contributor not present in list', () => {
+      const contrib1 = generateContributor({ id: 1 });
+      const contrib3 = generateContributor({ id: 3 });
+      const contrib2Copy = generateContributor({ id: 2 });
+
+      expect(findContributorIn([contrib1, contrib3])(contrib2Copy)).to.be
+        .undefined;
+    });
   });
 });

--- a/src/app/options/App/Settings/SubscriptionsScreen/Subscriptions.stories.tsx
+++ b/src/app/options/App/Settings/SubscriptionsScreen/Subscriptions.stories.tsx
@@ -1,52 +1,65 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { generateContributor } from 'test/fakers/generateContributor';
+import { generateStatefulContributor } from 'test/fakers/generateContributor';
 import Wrapper from '../../ScreenWrapper';
 import { SubscriptionsScreen } from './SubscriptionsScreen';
 
 storiesOf('screens/SubscriptionsScreen', module)
   .addDecorator(getStory => <Wrapper>{getStory()}</Wrapper>)
-  .add('subcriptions', () => (
-    <SubscriptionsScreen
-      subscriptions={[
-        generateContributor(),
-        { ...generateContributor(), subscribed: true },
-        generateContributor()
-      ]}
-      suggestions={[
-        generateContributor(),
-        { ...generateContributor(), subscribed: true },
-        generateContributor()
-      ]}
-      subscribe={() => action('subscribe')}
-      unsubscribe={() => action('unsubscribe')}
-      goToSuggestions={action('goToSuggestions')}
-    />
-  ))
-  .add('subcriptions empty', () => (
-    <SubscriptionsScreen
-      subscriptions={[]}
-      suggestions={[
-        generateContributor(),
-        { ...generateContributor(), subscribed: true },
-        generateContributor()
-      ]}
-      subscribe={() => action('subscribe')}
-      unsubscribe={() => action('unsubscribe')}
-      goToSuggestions={action('goToSuggestions')}
-    />
-  ))
-  .add('suggestions empty', () => (
-    <SubscriptionsScreen
-      subscriptions={[
-        generateContributor(),
-        { ...generateContributor(), subscribed: true },
-        generateContributor()
-      ]}
-      suggestions={[]}
-      subscribe={() => action('subscribe')}
-      unsubscribe={() => action('unsubscribe')}
-      goToSuggestions={action('goToSuggestions')}
-    />
-  ));
+  .add('subcriptions', () => {
+    const subscriptions = [
+      generateStatefulContributor({ subscribed: false }),
+      generateStatefulContributor({ subscribed: true }),
+      generateStatefulContributor({ subscribed: false })
+    ];
+    const suggestions = [
+      generateStatefulContributor({ subscribed: false }),
+      generateStatefulContributor({ subscribed: true }),
+      generateStatefulContributor({ subscribed: false })
+    ];
+    return (
+      <SubscriptionsScreen
+        subscriptions={subscriptions}
+        suggestions={suggestions}
+        allContributors={subscriptions.concat(suggestions)}
+        subscribe={() => action('subscribe')}
+        unsubscribe={() => action('unsubscribe')}
+        goToSuggestions={action('goToSuggestions')}
+      />
+    );
+  })
+  .add('subcriptions empty', () => {
+    const suggestions = [
+      generateStatefulContributor({ subscribed: false }),
+      generateStatefulContributor({ subscribed: true }),
+      generateStatefulContributor({ subscribed: false })
+    ];
+    return (
+      <SubscriptionsScreen
+        subscriptions={[]}
+        suggestions={suggestions}
+        allContributors={suggestions}
+        subscribe={() => action('subscribe')}
+        unsubscribe={() => action('unsubscribe')}
+        goToSuggestions={action('goToSuggestions')}
+      />
+    );
+  })
+  .add('suggestions empty', () => {
+    const subscriptions = [
+      generateStatefulContributor({ subscribed: false }),
+      generateStatefulContributor({ subscribed: true }),
+      generateStatefulContributor({ subscribed: false })
+    ];
+    return (
+      <SubscriptionsScreen
+        subscriptions={subscriptions}
+        suggestions={[]}
+        allContributors={subscriptions}
+        subscribe={() => action('subscribe')}
+        unsubscribe={() => action('unsubscribe')}
+        goToSuggestions={action('goToSuggestions')}
+      />
+    );
+  });

--- a/src/app/options/App/Settings/SubscriptionsScreen/SubscriptionsScreen.tsx
+++ b/src/app/options/App/Settings/SubscriptionsScreen/SubscriptionsScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import * as R from 'ramda';
 import { findContributorIn, StatefulContributor } from 'app/lmem/contributor';
 import ContributorLarge from 'components/organisms/Contributor/ContributorLarge';
 import Empty from './Empty';
@@ -23,6 +22,7 @@ const ContributorsList = styled.div`
 interface Props {
   subscriptions: StatefulContributor[];
   suggestions: StatefulContributor[];
+  allContributors: StatefulContributor[];
   subscribe: (contributor: StatefulContributor) => () => void;
   unsubscribe: (contributor: StatefulContributor) => () => void;
   goToSuggestions: () => void;
@@ -33,6 +33,7 @@ interface Props {
 export const SubscriptionsScreen = ({
   subscriptions,
   suggestions,
+  allContributors,
   subscribe,
   unsubscribe,
   goToSuggestions,
@@ -49,7 +50,7 @@ export const SubscriptionsScreen = ({
   }, [subscriptions]);
 
   const subscriptionsToRender = initialSubscriptions.map(
-    findContributorIn(R.concat(subscriptions, suggestions))
+    findContributorIn(allContributors)
   );
 
   if (subscriptionsToRender.length === 0) {
@@ -81,6 +82,7 @@ export const SubscriptionsScreen = ({
       <SuggestionsSidebar
         subscriptions={subscriptions}
         suggestions={suggestions}
+        allContributors={allContributors}
         subscribe={subscribe}
         unsubscribe={unsubscribe}
         goToSuggestions={goToSuggestions}

--- a/src/app/options/App/Settings/SubscriptionsScreen/SuggestionsSidebar/SuggestionsSidebar.tsx
+++ b/src/app/options/App/Settings/SubscriptionsScreen/SuggestionsSidebar/SuggestionsSidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import * as R from 'ramda';
 import { findContributorIn, StatefulContributor } from 'app/lmem/contributor';
 import ContributorCompact from 'components/organisms/Contributor/ContributorCompact';
 import CenterContainer from 'components/atoms/CenterContainer';
@@ -28,14 +27,15 @@ const SidebarEmpty = styled.p`
 interface Props {
   subscriptions: StatefulContributor[];
   suggestions: StatefulContributor[];
+  allContributors: StatefulContributor[];
   subscribe: (contributor: StatefulContributor) => () => void;
   unsubscribe: (contributor: StatefulContributor) => () => void;
   goToSuggestions: () => void;
 }
 
 const SuggestionsSidebar = ({
-  subscriptions,
   suggestions,
+  allContributors,
   subscribe,
   unsubscribe,
   goToSuggestions
@@ -47,7 +47,7 @@ const SuggestionsSidebar = ({
   }, [suggestions]);
 
   const suggestionsToRender = initialSuggestions.map(
-    findContributorIn(R.concat(subscriptions, suggestions))
+    findContributorIn(allContributors)
   );
 
   return (

--- a/src/app/options/App/Settings/SubscriptionsScreen/withConnect.ts
+++ b/src/app/options/App/Settings/SubscriptionsScreen/withConnect.ts
@@ -4,14 +4,16 @@ import { StatefulContributor } from 'app/lmem/contributor';
 import { subscribe, unsubscribe } from 'app/actions/subscription';
 import {
   getSubscriptions,
-  get5ContributorsSuggestions
+  get5ContributorsSuggestions,
+  getContributors
 } from 'app/options/store/selectors/contributors.selectors';
 import { OptionsState } from 'app/options/store/reducers';
 import { push } from 'connected-react-router';
 
 const mapStateToProps = (state: OptionsState) => ({
   subscriptions: getSubscriptions(state),
-  suggestions: get5ContributorsSuggestions(state)
+  suggestions: get5ContributorsSuggestions(state),
+  allContributors: getContributors(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/app/options/App/Settings/SuggestionsScreen/Suggestions.stories.tsx
+++ b/src/app/options/App/Settings/SuggestionsScreen/Suggestions.stories.tsx
@@ -2,26 +2,29 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import SuggestionsScreen from './SuggestionsScreen';
-import { generateContributor } from 'test/fakers/generateContributor';
+import { generateStatefulContributor } from 'test/fakers/generateContributor';
 import Wrapper from '../../ScreenWrapper';
 
 storiesOf('screens/SuggestionsScreen', module)
   .addDecorator(getStory => <Wrapper>{getStory()}</Wrapper>)
-  .add('suggestions', () => (
-    <SuggestionsScreen
-      subscriptions={[]}
-      suggestions={[
-        generateContributor(),
-        { ...generateContributor(), subscribed: true },
-        generateContributor()
-      ]}
-      subscribe={() => action('subscribe')}
-      unsubscribe={() => action('unsubscribe')}
-    />
-  ))
+  .add('suggestions', () => {
+    const suggestions = [
+      generateStatefulContributor({ subscribed: false }),
+      generateStatefulContributor({ subscribed: true }),
+      generateStatefulContributor({ subscribed: false })
+    ];
+    return (
+      <SuggestionsScreen
+        suggestions={suggestions}
+        allContributors={suggestions}
+        subscribe={() => action('subscribe')}
+        unsubscribe={() => action('unsubscribe')}
+      />
+    );
+  })
   .add('no suggestions', () => (
     <SuggestionsScreen
-      subscriptions={[]}
+      allContributors={[]}
       suggestions={[]}
       subscribe={() => action('subscribe')}
       unsubscribe={() => action('unsubscribe')}

--- a/src/app/options/App/Settings/SuggestionsScreen/SuggestionsScreen.tsx
+++ b/src/app/options/App/Settings/SuggestionsScreen/SuggestionsScreen.tsx
@@ -27,8 +27,8 @@ const ContributorsListEmpty = styled.p`
 `;
 
 export interface SuggestionsScreenProps {
-  subscriptions: StatefulContributor[];
   suggestions: StatefulContributor[];
+  allContributors: StatefulContributor[];
   subscribe: (contributor: StatefulContributor) => () => void;
   unsubscribe: (contributor: StatefulContributor) => () => void;
   showExampleLink?: boolean;
@@ -45,7 +45,7 @@ const addPreselectedContributors = (
   ) as StatefulContributor[]);
 
 const SuggestionsScreen = ({
-  subscriptions,
+  allContributors,
   suggestions,
   subscribe,
   unsubscribe,
@@ -56,8 +56,6 @@ const SuggestionsScreen = ({
   useEffect(() => {
     if (initialSuggestions.length === 0) setInitialSuggestions(suggestions);
   }, [suggestions]);
-
-  const allContributors = R.concat(subscriptions, suggestions);
 
   const suggestionsToRender = R.pipe(
     R.map(findContributorIn(allContributors)),

--- a/src/app/options/App/Settings/SuggestionsScreen/withConnect.ts
+++ b/src/app/options/App/Settings/SuggestionsScreen/withConnect.ts
@@ -4,13 +4,15 @@ import { StatefulContributor } from 'app/lmem/contributor';
 import { subscribe, unsubscribe } from 'app/actions/subscription';
 import { OptionsState } from 'app/options/store/reducers';
 import {
+  getContributors,
   getContributorsSuggestions,
   getSubscriptions
 } from 'app/options/store/selectors/contributors.selectors';
 
 const mapStateToProps = (state: OptionsState) => ({
   subscriptions: getSubscriptions(state),
-  suggestions: getContributorsSuggestions(state)
+  suggestions: getContributorsSuggestions(state),
+  allContributors: getContributors(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/components/organisms/Contributor/Contributor.stories.tsx
+++ b/src/components/organisms/Contributor/Contributor.stories.tsx
@@ -2,20 +2,34 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import ContributorLarge from './ContributorLarge';
 import ContributorCompact from './ContributorCompact';
-import { generateContributor } from '../../../../test/fakers/generateContributor';
+import { generateStatefulContributor } from 'test/fakers/generateContributor';
 import { action } from '@storybook/addon-actions';
 
 storiesOf('organisms/Contributor', module)
-  .add('large', () => (
+  .add('large unsubscribed', () => (
     <ContributorLarge
-      contributor={generateContributor()}
+      contributor={generateStatefulContributor({ subscribed: false })}
       onSubscribe={action('onSubscribe')}
       onUnsubscribe={action('onUnsubscribe')}
     />
   ))
-  .add('compact', () => (
+  .add('large subscribed', () => (
+    <ContributorLarge
+      contributor={generateStatefulContributor({ subscribed: true })}
+      onSubscribe={action('onSubscribe')}
+      onUnsubscribe={action('onUnsubscribe')}
+    />
+  ))
+  .add('compact unsubscribed', () => (
     <ContributorCompact
-      contributor={generateContributor()}
+      contributor={generateStatefulContributor({ subscribed: false })}
+      onSubscribe={action('onSubscribe')}
+      onUnsubscribe={action('onUnsubscribe')}
+    />
+  ))
+  .add('compact subscribed', () => (
+    <ContributorCompact
+      contributor={generateStatefulContributor({ subscribed: true })}
       onSubscribe={action('onSubscribe')}
       onUnsubscribe={action('onUnsubscribe')}
     />

--- a/test/fakers/generateContributor.ts
+++ b/test/fakers/generateContributor.ts
@@ -18,7 +18,7 @@ export const generateContributor = ({
   contributions,
   noAvatar
 }: Options = {}): Contributor => ({
-  id: id || 42,
+  id: id || Faker.random.number(),
   name: name || Faker.name.findName(),
   contributions: contributions || Faker.random.number(),
   contribution: {


### PR DESCRIPTION
`SubscriptionsScreen`, `SuggestionsScreen` and `SuggestionsSidebar` were all assuming that all contributors are found in `suggestions.concat(subscriptions)`. 

Since we started limiting the number of `suggestions` in the connector, this is not true anymore, and this was generating crashes upon subscribe/unsubscribe. 

This changes resolves the issue by adding an explicit `allContributors` connected props that should avoid any future confusion. 