### PR TITLE
chore(sentry): ignore resizeObserver loop errors

### DIFF
--- a/src/app/utils/sentry.ts
+++ b/src/app/utils/sentry.ts
@@ -1,15 +1,27 @@
 import {
   init,
   configureScope,
-  Scope,
-  Severity,
   captureMessage as sentryCaptureMessage,
   captureException as sentryCaptureException
 } from '@sentry/browser';
+import { Scope, Severity, Event, EventHint } from '@sentry/types/dist';
 import { getRelease } from '../../../sentry';
 import Logger from './Logger';
 
 let sentryInitialized = false;
+
+const beforeSend = (event: Event, hint: EventHint) => {
+  const error = hint.originalException;
+  if (
+    error &&
+    typeof error === 'object' &&
+    error.message &&
+    error.message.match(/ResizeObserver loop limit exceeded/i)
+  ) {
+    return null;
+  }
+  return event;
+};
 
 export const initSentry = () => {
   const blacklist = ['GlobalHandlers', 'ReportingObserver', 'CaptureConsole'];
@@ -20,7 +32,8 @@ export const initSentry = () => {
         environment: process.env.NODE_ENV,
         release: getRelease(process.env.BUILD),
         integrations: integrations =>
-          integrations.filter(i => !blacklist.includes(i.name))
+          integrations.filter(i => !blacklist.includes(i.name)),
+        beforeSend
       });
       sentryInitialized = true;
       Logger.info('Sentry initialized');


### PR DESCRIPTION
Resolves https://sentry.io/organizations/lmem/issues/1051206071/events/c8008253756b4067b3a15a4544c49e29/?project=1404847&statsPeriod=30d (4 500 occurences)

because it does not matter : https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded