### PR TITLE
fix: Sagas don't wait for store to be rehydrated

### DIFF
--- a/src/app/background/sagas/index.ts
+++ b/src/app/background/sagas/index.ts
@@ -1,4 +1,4 @@
-import { fork, all } from 'redux-saga/effects';
+import { fork, all, call } from 'redux-saga/effects';
 import install from './install';
 import tab from './tab';
 import badge from './badge';
@@ -16,8 +16,11 @@ import sendContributorsToOptions from './transmitContributors.saga';
 import sendInstallationDetailsToOptions from './sendInstallationDetailsToOptions.saga';
 import setup from './setup.saga';
 import tos from './tos.saga';
+import awaitRehydratationSaga from './lib/awaitRehydratation.saga';
 
 export default function* rootSaga() {
+  yield call(awaitRehydratationSaga);
+
   yield all([
     fork(install),
     fork(refreshMatchingContexts),

--- a/src/app/background/sagas/install.ts
+++ b/src/app/background/sagas/install.ts
@@ -1,6 +1,5 @@
 import { SagaIterator } from 'redux-saga';
-import { takeLatest, select, put, call, take, all } from 'redux-saga/effects';
-import { REHYDRATE } from 'redux-persist';
+import { takeLatest, select, put, call, all } from 'redux-saga/effects';
 import { captureException } from 'app/utils/sentry';
 import openOptions from 'webext/openOptionsTab';
 import {
@@ -9,8 +8,7 @@ import {
 } from 'app/actions/install';
 import {
   isAnUpdateFromLmem,
-  isOnboardingRequired,
-  isRehydrated
+  isOnboardingRequired
 } from 'app/background/selectors';
 import { areTosAccepted } from 'app/background/selectors/prefs';
 import { getInstallationDate } from 'app/background/selectors/installationDetails';
@@ -34,11 +32,6 @@ export function* installedSaga({
       datetime: datetime || new Date(),
       updatedAt: new Date()
     };
-
-    const rehydrated = yield select(isRehydrated);
-    if (!rehydrated) {
-      yield take(REHYDRATE);
-    }
 
     yield put(updateInstallationDetails(installationDetails, false));
   } catch (e) {

--- a/src/app/background/sagas/lib/awaitRehydratation.saga.ts
+++ b/src/app/background/sagas/lib/awaitRehydratation.saga.ts
@@ -1,0 +1,17 @@
+import { select, take } from '@redux-saga/core/effects';
+import { REHYDRATE } from 'redux-persist/es/constants';
+import { isRehydrated } from '../../selectors';
+import Logger from '../../../utils/Logger';
+
+function* awaitRehydratationSaga() {
+  Logger.debug('Checking store rehydratation ...');
+  const rehydrated = yield select(isRehydrated);
+  Logger.debug(`Store is ${rehydrated ? '' : 'not '}rehydrated!`);
+  if (!rehydrated) {
+    Logger.debug('Waiting for store rehydratation ...');
+    yield take(REHYDRATE);
+  }
+  Logger.info('Store rehydrated check done');
+}
+
+export default awaitRehydratationSaga;


### PR DESCRIPTION
We weren't making sure that store is rehydrated before launching all sagas. This can cause a lot of problems, among which the fact that first matching context fetch does not care about the users subscriptions ... giving a wrong experience for half-an-hour (before next refresh) ...

This fixes the issue the hard way : We don't start any background saga before store has been rehydrated. I wanted at first to wait in specific sagas, in case we ever want to have a saga to run before store rehydratation, but since I could not find any current use case, I just wrote a general await. 

This resolves at least https://trello.com/c/j9ciqrcq

But this may also be the root cause for https://trello.com/c/CANbCw0v and https://trello.com/c/Gmmivt8o and other bugs