### PR TITLE
chore(would-it-match): allow detection of a matching context even with no subscriptions

### DIFF
--- a/src/app/actions/serviceMessage.actions.ts
+++ b/src/app/actions/serviceMessage.actions.ts
@@ -1,27 +1,18 @@
 import { TabAction } from './';
 import Tab from 'app/lmem/tab';
-import { ServiceMessageAction } from '../content/reducers/serviceMessage.reducer';
+import ServiceMessage from 'app/lmem/ServiceMessage';
 
 export const SHOW_SERVICE_MESSAGE = 'SHOW_SERVICE_MESSAGE';
 export interface ShowServiceMessageAction extends TabAction {
   type: typeof SHOW_SERVICE_MESSAGE;
-  payload: {
-    date: Date;
-    messages: string[];
-    action: ServiceMessageAction | null;
-  };
+  payload: ServiceMessage;
 }
 export const showServiceMessage = (
-  messages: string[],
-  tab: Tab,
-  action: ServiceMessageAction | null = null
+  serviceMessage: ServiceMessage,
+  tab: Tab
 ): ShowServiceMessageAction => ({
   type: SHOW_SERVICE_MESSAGE,
-  payload: {
-    date: new Date(),
-    messages,
-    action
-  },
+  payload: { ...serviceMessage, lastShownDate: new Date() },
   meta: {
     tab,
     sendToTab: true

--- a/src/app/actions/ui.ts
+++ b/src/app/actions/ui.ts
@@ -10,7 +10,13 @@ export const OPEN = 'OPEN';
 export interface OpenAction extends BaseAction {
   type: typeof OPEN;
 }
-export const open = (): OpenAction => ({ type: OPEN });
+export const open = (tab?: Tab): OpenAction => ({
+  type: OPEN,
+  meta: {
+    sendToTab: !!tab,
+    tab
+  }
+});
 
 export const OPENED = 'OPENED';
 export interface OpenedAction extends BaseAction {

--- a/src/app/background/reducers/serviceMessage.reducer.spec.ts
+++ b/src/app/background/reducers/serviceMessage.reducer.spec.ts
@@ -14,10 +14,17 @@ describe('background > reducers > serviceMessage', () => {
   it('saves the lastShownDate from SHOW_SERVICE_MESSAGE action', () => {
     const now = new Date();
     const clock = useFakeTimers(now.getTime());
-    const action = showServiceMessage(["Hey there I'm a service message"], {
-      id: 1,
-      url: ''
-    });
+    const action = showServiceMessage(
+      {
+        messages: ["Hey there I'm a service message"],
+        lastShownDate: null,
+        action: null
+      },
+      {
+        id: 1,
+        url: ''
+      }
+    );
     const state: ServiceMessageState = {
       lastShownDate: null
     };

--- a/src/app/background/reducers/serviceMessage.reducer.ts
+++ b/src/app/background/reducers/serviceMessage.reducer.ts
@@ -19,7 +19,7 @@ export default (
   switch (action.type) {
     case SHOW_SERVICE_MESSAGE: {
       return {
-        lastShownDate: action.payload.date
+        lastShownDate: action.payload.lastShownDate
       };
     }
 

--- a/src/app/background/sagas/handleBrowserAction.saga.ts
+++ b/src/app/background/sagas/handleBrowserAction.saga.ts
@@ -1,32 +1,15 @@
-import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { put, takeLatest } from 'redux-saga/effects';
 import { CloseCause } from 'app/lmem/ui';
 import {
   BROWSER_ACTION_CLICKED,
   toggleUI,
-  BrowserActionClickedAction,
-  createErrorAction
+  BrowserActionClickedAction
 } from 'app/actions';
-import { areTosAccepted } from '../selectors/prefs';
-import { getNbSubscriptions } from '../selectors/subscriptions.selectors';
-import serviceMessageSaga from './serviceMessage.saga';
-import { getNumberOfUnreadNoticesOnTab } from '../selectors';
 
 export function* browserActionClickedSaga({
   meta: { tab }
 }: BrowserActionClickedAction) {
-  try {
-    const tosAccepted = yield select(areTosAccepted);
-    const nbSubscriptions = yield select(getNbSubscriptions);
-    const nbNotices = yield select(getNumberOfUnreadNoticesOnTab(tab.id));
-
-    if (tosAccepted && nbSubscriptions > 0) {
-      yield put(toggleUI(tab, CloseCause.BrowserAction));
-    } else {
-      yield call(serviceMessageSaga, tab, nbNotices);
-    }
-  } catch (e) {
-    yield put(createErrorAction()(e));
-  }
+  yield put(toggleUI(tab, CloseCause.BrowserAction));
 }
 
 export default function* backgroundRootSaga() {

--- a/src/app/background/sagas/refreshMatchingContexts.ts
+++ b/src/app/background/sagas/refreshMatchingContexts.ts
@@ -10,12 +10,11 @@ import { getSubscriptions } from '../selectors/subscriptions.selectors';
 
 function* refreshMatchingContexts() {
   try {
-    const subscriptions = yield select(getSubscriptions);
-    const matchingContexts =
-      subscriptions.length > 0
-        ? yield call(fetchMatchingContexts, subscriptions)
-        : [];
-    yield put(receivedMatchingContexts(matchingContexts));
+    yield put(
+      receivedMatchingContexts(
+        yield call(fetchMatchingContexts, yield select(getSubscriptions))
+      )
+    );
   } catch (e) {
     yield put(refreshMatchingContextsFailed(e));
   }

--- a/src/app/content/App/ServiceMessage/ServiceMessage.tsx
+++ b/src/app/content/App/ServiceMessage/ServiceMessage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { BackgroundButton } from 'components/atoms';
-import { ServiceMessageAction } from 'app/content/reducers/serviceMessage.reducer';
+import { ServiceMessageAction } from 'app/lmem/ServiceMessage';
 
 const Content = styled.section`
   margin-top: 50px;

--- a/src/app/content/reducers/serviceMessage.reducer.spec.ts
+++ b/src/app/content/reducers/serviceMessage.reducer.spec.ts
@@ -14,16 +14,24 @@ describe('content > reducers > serviceMessage', () => {
   it('shows update message when receive SHOW_SERVICE_MESSAGE', () => {
     const state: ServiceMessageState = {
       messages: [],
-      action: null
+      action: null,
+      lastShownDate: null
     };
     expect(
-      serviceMessage(state, showServiceMessage(['message'], { id: 1, url: '' }))
+      serviceMessage(
+        state,
+        showServiceMessage(
+          { messages: ['message'], lastShownDate: null, action: null },
+          { id: 1, url: '' }
+        )
+      )
     ).to.have.deep.property('messages', ['message']);
   });
   it('removes the update message when UI is CLOSED', () => {
     const state: ServiceMessageState = {
       messages: [],
-      action: null
+      action: null,
+      lastShownDate: null
     };
     expect(
       serviceMessage(state, closed(CloseCause.CloseButton))

--- a/src/app/content/reducers/serviceMessage.reducer.ts
+++ b/src/app/content/reducers/serviceMessage.reducer.ts
@@ -1,18 +1,12 @@
 import { CLOSED, SHOW_SERVICE_MESSAGE, AppAction } from 'app/actions';
+import ServiceMessage from 'app/lmem/ServiceMessage';
 
-export interface ServiceMessageAction {
-  label: string;
-  url: string;
-}
-
-export interface ServiceMessageState {
-  messages: string[];
-  action: ServiceMessageAction | null;
-}
+export type ServiceMessageState = ServiceMessage;
 
 const initialState: ServiceMessageState = {
   messages: [],
-  action: null
+  action: null,
+  lastShownDate: null
 };
 
 export default (
@@ -21,13 +15,11 @@ export default (
 ): ServiceMessageState => {
   switch (action.type) {
     case SHOW_SERVICE_MESSAGE: {
-      return {
-        messages: action.payload.messages,
-        action: action.payload.action
-      };
+      return action.payload;
     }
     case CLOSED: {
       return {
+        lastShownDate: null,
         messages: [],
         action: null
       };

--- a/src/app/content/sagas/ui/index.tsx
+++ b/src/app/content/sagas/ui/index.tsx
@@ -18,7 +18,6 @@ import {
   open,
   opened,
   openFailed,
-  SHOW_SERVICE_MESSAGE,
   TOGGLE_UI,
   OPENED,
   CLOSE,
@@ -117,7 +116,7 @@ export function* loadedSaga() {
 export default function* UISaga() {
   yield takeLatest(OPEN, openSaga);
   yield takeLatest(CLOSE, closeSaga);
-  yield takeEvery([TOGGLE_UI, SHOW_SERVICE_MESSAGE], toggleUISaga);
+  yield takeEvery(TOGGLE_UI, toggleUISaga);
   yield takeLatest(NOTICES_FOUND, noticesFoundSaga);
   yield takeLatest(OPENED, fakeLoadingSaga);
   yield takeLatest(LOADED, loadedSaga);

--- a/src/app/content/selectors/serviceMessage.selectors.spec.ts
+++ b/src/app/content/selectors/serviceMessage.selectors.spec.ts
@@ -1,9 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
-import {
-  hasServiceMessage,
-  StateWithServiceMessage
-} from './serviceMessage.selectors';
+import { hasServiceMessage } from './serviceMessage.selectors';
+import { StateWithServiceMessage } from '../store';
 
 describe('content > selectors > serviceMessage', () => {
   describe('serviceMessage', () => {
@@ -11,7 +9,8 @@ describe('content > selectors > serviceMessage', () => {
       const state: StateWithServiceMessage = {
         serviceMessage: {
           messages: [],
-          action: null
+          action: null,
+          lastShownDate: null
         }
       };
       expect(hasServiceMessage(state)).to.be.false;
@@ -20,7 +19,8 @@ describe('content > selectors > serviceMessage', () => {
       const state: StateWithServiceMessage = {
         serviceMessage: {
           messages: ["Hey I'm a service message."],
-          action: null
+          action: null,
+          lastShownDate: null
         }
       };
       expect(hasServiceMessage(state)).to.be.true;

--- a/src/app/content/selectors/serviceMessage.selectors.ts
+++ b/src/app/content/selectors/serviceMessage.selectors.ts
@@ -1,10 +1,7 @@
 import { createSelector } from 'reselect';
 import * as R from 'ramda';
+import { StateWithServiceMessage } from '../store';
 import { ServiceMessageState } from '../reducers/serviceMessage.reducer';
-
-export interface StateWithServiceMessage {
-  serviceMessage: ServiceMessageState;
-}
 
 export const getServiceMessageState = (
   state: StateWithServiceMessage

--- a/src/app/content/store.ts
+++ b/src/app/content/store.ts
@@ -13,15 +13,17 @@ import { ContributorsState } from 'app/options/store/reducers/contributors.reduc
 
 export const history = createMemoryHistory();
 
-export interface ContentState {
+export interface StateWithServiceMessage {
+  serviceMessage: ServiceMessageState;
+}
+export type ContentState = StateWithServiceMessage & {
   installationDetails: InstallationDetailsState;
   ui: UIState;
   notices: NoticesState;
   router: RouterState;
   form: FormStateMap;
-  serviceMessage: ServiceMessageState;
   contributors: ContributorsState;
-}
+};
 
 const sagaMiddleware = createSagaMiddleware();
 

--- a/src/app/lmem/ServiceMessage.ts
+++ b/src/app/lmem/ServiceMessage.ts
@@ -1,0 +1,10 @@
+export interface ServiceMessageAction {
+  label: string;
+  url: string;
+}
+
+export default interface ServiceMessageState {
+  messages: string[];
+  action: ServiceMessageAction | null;
+  lastShownDate: null | Date;
+}


### PR DESCRIPTION
* go back to fetching all matching contexts when no subscriptions are presents
* refactor service message saga to be self contained
* do not toggle UI on some random action, toggle (or open) explicitly if needed
* break tab saga if "installation is not complete"