### PR TITLE
fix(firefox): revert animations refactoring because of a crash with firefox

### DIFF
--- a/src/app/content/App/Notice/List/index.tsx
+++ b/src/app/content/App/Notice/List/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { compose } from 'redux';
-import { Transition } from 'react-spring/renderprops';
+import { useTransition } from 'react-spring';
 
 import { AddNoticeContainer, AddNoticeButton } from 'components/atoms';
-import NoticeItem from 'components/organisms/Notice/Notice';
-import { height, marginBottom } from 'components/organisms/Notice/Container';
+import NoticeItem, {
+  NoticeTransitionProps,
+  transitionKeys
+} from 'components/organisms/Notice/Notice';
 import ListContainer from './ListContainer';
 import { StatefulNotice } from 'app/lmem/notice';
 import withTitle from 'app/hocs/withTitle';
@@ -26,31 +28,21 @@ export const ListScreen = ({
   undismiss,
   clickContributor
 }: Props) => {
+  const transitions = useTransition(
+    notices.slice(0, 2),
+    notice => notice.id,
+    // eslint-disable-next-line
+    // @ts-ignore
+    transitionKeys
+  );
+
   return (
     <>
       <ListContainer>
-        <Transition
-          items={notices}
-          keys={notice => notice.id}
-          from={{
-            height,
-            marginBottom,
-            opacity: 0,
-            transform: 'translate3d(0%,100%,0)'
-          }}
-          enter={{ opacity: 1, transform: 'translate3d(0%,0%,0)' }}
-          leave={() => async (next: (...args: any[]) => Promise<{}>) => {
-            await next({ opacity: 0, transform: 'translate3d(95%,0%,0)' });
-            await next({ height: 0, marginBottom: 0 });
-          }}
-          reset={false}
-          trail={250}
-          config={{ tension: 180, friction: 20 }}
-          unique
-          native
-        >
-          {notice => props => (
+        {transitions.map(
+          ({ item: notice, props, key }: NoticeTransitionProps) => (
             <NoticeItem
+              key={key}
               style={props}
               notice={notice}
               dismiss={dismiss}
@@ -58,8 +50,8 @@ export const ListScreen = ({
               undismiss={undismiss}
               clickContributor={clickContributor}
             />
-          )}
-        </Transition>
+          )
+        )}
       </ListContainer>
       {notices.length === 0 && <NoNotice />}
       {notices.length > 0 && (

--- a/src/components/organisms/Notice/Notice.tsx
+++ b/src/components/organisms/Notice/Notice.tsx
@@ -1,10 +1,9 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
-import { animated } from 'react-spring/renderprops';
 import { stripHtml } from 'app/utils/stripHtml';
 import { Contributor, Button, Timer, CenterContainer } from 'components/atoms';
 import InteractiveAvatar from 'components/molecules/InteractiveAvatar';
-import Container from './Container';
+import Container, { height, marginBottom } from './Container';
 import Content from './Content';
 import Deleted from './Deleted';
 import DeleteButton from './DeleteButton';
@@ -14,6 +13,24 @@ import {
   CountDownState,
   initialState as countdownInitialState
 } from 'app/lmem/countdown';
+
+export const transitionKeys = {
+  from: {
+    height,
+    marginBottom,
+    opacity: 0,
+    transform: 'translate3d(0%,100%,0)'
+  },
+  enter: { opacity: 1, transform: 'translate3d(0%,0%,0)' },
+  leave: () => async (next: (...args: any[]) => Promise<{}>) => {
+    await next({ opacity: 0, transform: 'translate3d(95%,0%,0)' });
+    await next({ height: 0, marginBottom: 0 });
+  },
+  trail: 250,
+  unique: true,
+  reset: false,
+  config: { tension: 180, friction: 20 }
+};
 
 const Description = styled.div`
   width: 245px;
@@ -26,6 +43,12 @@ const ContributorName = styled(Contributor)`
   }
 `;
 
+export interface NoticeTransitionProps {
+  item: StatefulNotice;
+  props: object;
+  key: string;
+}
+
 interface Props {
   notice: StatefulNotice;
   dismiss: (id: number) => void;
@@ -36,7 +59,7 @@ interface Props {
   style?: object;
 }
 
-class Notice extends PureComponent<Props, CountDownState> {
+export default class Notice extends PureComponent<Props, CountDownState> {
   constructor(props: Props) {
     super(props);
     this.state = countdownInitialState;
@@ -156,5 +179,3 @@ class Notice extends PureComponent<Props, CountDownState> {
     );
   }
 }
-
-export default animated(Notice);

--- a/webpack/config.plugins.js
+++ b/webpack/config.plugins.js
@@ -28,7 +28,8 @@ const selectEnvVarsToInject = R.pick([
   'REFRESH_CONTRIBUTORS_INTERVAL',
   'TRACKING_URL',
   'TRACKING_SITE_ID',
-  'SENTRY_ENABLED'
+  'SENTRY_ENABLED',
+  'PLATFORM'
 ]);
 const formatEnvVars = R.map(value => `"${value}"`);
 


### PR DESCRIPTION
We're executing animations in the context of an iframe, in order for this to work we need to use
the right window.requestAnimationFrame, there are fixes possible, but would need to dig a bit.
The best solution would be to use a react frame library, that handle all the quirks of the iframe
See #192 for example