### PR TITLE
fix(pdf): fix more PDF injection cases which are breaking printing PDF feature

### DIFF
--- a/manifest/base.js
+++ b/manifest/base.js
@@ -21,13 +21,13 @@ module.exports = Object.freeze({
   content_scripts: [
     {
       exclude_globs: [
-        '*.pdf',
-        '*.Pdf',
-        '*.PDF',
-        '*.jpeg',
-        '*.jpg',
-        '*.png',
-        '*.gif'
+        '*.pdf*',
+        '*.Pdf*',
+        '*.PDF*',
+        '*.jpeg*',
+        '*.jpg*',
+        '*.png*',
+        '*.gif*'
       ],
       matches: ['*://*/*'],
       exclude_matches: [


### PR DESCRIPTION
Previous globs weren't matching that kind of URLs:
> https://backmarket-prod.s3.amazonaws.com/delivery_form/20200204_055944_5104243_5104243.pdf?Signature=oWclp765ikC%2Bg0J85nzaJWG7uVw%3D&Expires=1581004481&AWSAccessKeyId=AKIA3KCUUZOWLAHCM2MH

Mind the querystring part of the URL...