### PR TITLE
pipeline(chrome): add a `deploy:chrome` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "storybook": "start-storybook --ci -p 6007 -c .storybook",
     "build-storybook": "build-storybook",
     "deploy": "DEPLOY=staging yarn semantic-release",
-    "deploy:production": "DEPLOY=production yarn semantic-release"
+    "deploy:production": "DEPLOY=production yarn semantic-release",
+    "deploy:chrome": "yarn run upload:chrome:staging && yarn run upload:chrome:proding"
   },
   "husky": {
     "hooks": {

--- a/release.config.staging.js
+++ b/release.config.staging.js
@@ -37,10 +37,6 @@ const release = Object.freeze({
       path: '@semantic-release/exec',
       cmd: 'yarn run sign:firefox:staging'
     },
-    {
-      path: '@semantic-release/exec',
-      cmd: 'yarn run upload:chrome:staging'
-    },
 
     // proding
     {
@@ -50,10 +46,6 @@ const release = Object.freeze({
     {
       path: '@semantic-release/exec',
       cmd: 'yarn run sign:firefox:proding'
-    },
-    {
-      path: '@semantic-release/exec',
-      cmd: 'yarn run upload:chrome:proding'
     },
 
     {


### PR DESCRIPTION
I think we don't nee to create another semantic release script in this case.
Also I'm configuring another server in semaphore that would execute the script.