### PR TITLE
fix(UI): fix cases where iframes are hidden in host page CSS

### DIFF
--- a/src/app/content/extensionIframe.ts
+++ b/src/app/content/extensionIframe.ts
@@ -29,7 +29,11 @@ export const append = (iframe: HTMLIFrameElement): Promise<Document | null> =>
 export const show = () => {
   const frame = document.querySelector(`#${iFrameId}`);
   if (frame) {
-    (frame as HTMLIFrameElement).style.removeProperty('display');
+    (frame as HTMLIFrameElement).style.setProperty(
+      'display',
+      'block',
+      'important'
+    );
   }
 };
 

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -76,6 +76,7 @@ export interface Theme {
       width: string;
       height: string;
       left: string;
+      display: string;
     };
   };
 }
@@ -172,7 +173,8 @@ export const theme: Theme = {
       transition: 'height .1s',
       width: '390px',
       height: '423px',
-      left: 'auto'
+      left: 'auto',
+      display: 'block'
     }
   }
 };


### PR DESCRIPTION
On http://118-918.fr/ website, host page has the following css: 
```
iframe {
    display: none;
}
```
Since we're just removing the display property from our own style, the host page css was taking precedence over.

> https://trello.com/c/nltlxKRC/394-une-bulle-qui-est-bien-signal%C3%A9e-par-le-badge-mais-qui-ne-saffiche-pas