### PR TITLE
fix(service-message): The service message won't stay if subscriptions…

### DIFF
--- a/src/app/background/sagas/tab.ts
+++ b/src/app/background/sagas/tab.ts
@@ -54,6 +54,7 @@ export function* tabSaga({ meta: { tab } }: TabAction) {
 
 export function* matchContextSaga({ meta: { tab } }: MatchContextAction) {
   try {
+    yield put(clearServiceMessage(tab));
     const triggeredContexts = yield select(state =>
       findTriggeredContexts(state)(tab.url)
     );


### PR DESCRIPTION
… changed

This is quick fix, but we could go further and do all the service message computation in the match context saga, that would also mean changing a bit the code behind the notices to display.

This commit also don't close the UI when the context is not triggered.