### PR TITLE
chore: Reduce build size by importing core-js

### DIFF
--- a/src/app/background/index.ts
+++ b/src/app/background/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 // Early imports with high priority stuff involved, such as event listeners creation
+import 'core-js/stable';
 import { BACKEND_ORIGIN } from 'app/constants/origins';
 import onInstalled from 'webext/onInstalled';
 import onStartup from 'webext/onStartup';

--- a/src/app/content/index.ts
+++ b/src/app/content/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires, import/first */
+import 'core-js/stable';
 import Logger from 'app/utils/Logger';
 Logger.info('Content script injected...');
 

--- a/src/app/options/index.tsx
+++ b/src/app/options/index.tsx
@@ -1,3 +1,4 @@
+import 'core-js/stable';
 import { configureSentryScope, initSentry, Scope } from '../utils/sentry';
 
 initSentry();

--- a/webpack/config.entry.js
+++ b/webpack/config.entry.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const polyfills = ['core-js/stable', 'regenerator-runtime/runtime'];
+const polyfills = ['regenerator-runtime/runtime'];
 
 module.exports = (env, srcPath) => ({
   background: [...polyfills, path.join(srcPath, './app/background/')],


### PR DESCRIPTION
Something seems wrong with our config, just with this change it seems the size of included core-js functions is reduced 4 times...