### PR TITLE
fix(matching-contexts): Fix a bug where matching contexts were empty

### DIFF
--- a/src/api/fetchMatchingContexts.ts
+++ b/src/api/fetchMatchingContexts.ts
@@ -3,7 +3,7 @@ import { MatchingContext } from 'app/lmem/matchingContext';
 import { get } from './call';
 
 const fetchMatchingContexts = (
-  subscriptions: ContributorId[]
+  subscriptions: ContributorId[] = []
 ): Promise<MatchingContext[]> =>
   get('matching-contexts', { contributors: subscriptions });
 


### PR DESCRIPTION
This was leading to call /api/v3/matching-contexts?contributors=undefined which return empty result
-> nothing was matching anymore -_-