### PR TITLE
chore: Change refresh intervals to values that make some sense

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -2,8 +2,8 @@ NODE_ENV=development
 BACKEND_ORIGIN=https://staging-notices.bulles.fr/api/v3/
 
 # Refresh intervals in minutes
-REFRESH_MC_INTERVAL=300
-REFRESH_CONTRIBUTORS_INTERVAL=300
+REFRESH_MC_INTERVAL=5
+REFRESH_CONTRIBUTORS_INTERVAL=5
 
 # UNINSTALL_ORIGIN=https://www.bulles.fr/desinstallation
 

--- a/.env.proding
+++ b/.env.proding
@@ -1,8 +1,8 @@
 BACKEND_ORIGIN=https://notices.bulles.fr/api/v3/
 
 # Refresh intervals in minutes
-REFRESH_MC_INTERVAL=300
-REFRESH_CONTRIBUTORS_INTERVAL=300
+REFRESH_MC_INTERVAL=5
+REFRESH_CONTRIBUTORS_INTERVAL=5
 
 UNINSTALL_ORIGIN=https://www.bulles.fr/desinstallation
 

--- a/.env.production
+++ b/.env.production
@@ -1,8 +1,8 @@
 BACKEND_ORIGIN=https://notices.bulles.fr/api/v3/
 
 # Refresh intervals in minutes
-REFRESH_MC_INTERVAL=1800
-REFRESH_CONTRIBUTORS_INTERVAL=1800
+REFRESH_MC_INTERVAL=30
+REFRESH_CONTRIBUTORS_INTERVAL=30
 
 UNINSTALL_ORIGIN=https://www.bulles.fr/desinstallation
 

--- a/.env.staging
+++ b/.env.staging
@@ -1,8 +1,8 @@
 BACKEND_ORIGIN=https://staging-notices.bulles.fr/api/v3/
 
 # Refresh intervals in minutes
-REFRESH_MC_INTERVAL=300
-REFRESH_CONTRIBUTORS_INTERVAL=300
+REFRESH_MC_INTERVAL=5
+REFRESH_CONTRIBUTORS_INTERVAL=5
 
 UNINSTALL_ORIGIN=https://www.bulles.fr/desinstallation
 

--- a/src/app/background/sagas/refreshMatchingContexts.ts
+++ b/src/app/background/sagas/refreshMatchingContexts.ts
@@ -20,9 +20,7 @@ export function* refreshMatchingContextsPeriodicallySaga() {
   if (refreshInterval > 0) {
     // eslint-disable-next-line no-console
     console.info(
-      `Matching contexts will be refreshed every ${refreshInterval /
-        1000 /
-        60} minutes.`
+      `Matching contexts will be refreshed every ${process.env.REFRESH_MC_INTERVAL} minutes.`
     );
 
     while (true) {


### PR DESCRIPTION
**dev**
- Matching contexts: 5 minutes
- Contributors: 5 minutes

**staging & proding**
- Matching contexts: 5 minutes
- Contributors: 5 minutes

**production**
- Matching contexts: 30 minutes
- Contributors: 30 minutes

> I think for production it was the previously intended values.

Let me know if you think that some values would be more appropriate.