### PR TITLE
fix: Typo on sample notice screenshot alternative text

### DIFF
--- a/src/app/profiles/App/Profiles/Profile/ProfileNoticeListItem.tsx
+++ b/src/app/profiles/App/Profiles/Profile/ProfileNoticeListItem.tsx
@@ -90,7 +90,7 @@ export const ProfileNoticeListItem = ({
         <img
           style={{ width: '100%' }}
           src={notice.screenshot}
-          alt={`Rendu de la contribution sur ${notice.exampleUrl} avec l'extension installé.`}
+          alt={`Rendu de la contribution sur ${notice.exampleUrl} une fois l'extension installée.`}
         />
       )}
       <Paragraph dangerouslySetInnerHTML={{ __html: notice.strippedMessage }} />


### PR DESCRIPTION
I was browsing https://www.dismoi.io/les-contributeurs/32/Colibri-ecolo and the screenshot of the second notice was not loading.
I wonder if it's a known issue @JalilArfaoui .

As for text itself, it's only supposed to appears on screen readers and if something prevent the image from loading.