### PR TITLE
fix: Browser action click not toggling UI

### DIFF
--- a/src/app/actions/tabs.ts
+++ b/src/app/actions/tabs.ts
@@ -1,8 +1,8 @@
 import { InstallationDetails } from 'app/lmem/installation';
 import { MatchingContext } from 'app/lmem/matchingContext';
-import Tab from 'app/lmem/tab';
+import Tab, { TabWithURL } from 'app/lmem/tab';
 import { ReceivedAction } from 'webext/createMessageHandler';
-import { BaseAction, TabAction, TabErrorAction } from '.';
+import { BaseAction, TabAction, TabErrorAction, TabMeta } from '.';
 import { Level } from '../utils/Logger';
 
 export const INIT = 'INIT';
@@ -41,8 +41,11 @@ export const navigatedToUrl = (url: string): NavigatedToUrlAction => ({
 export const MATCH_CONTEXT = 'LMEM/MATCH_CONTEXT';
 export interface MatchContextAction extends TabAction {
   type: typeof MATCH_CONTEXT;
+  meta: TabMeta & {
+    tab: TabWithURL;
+  };
 }
-export const matchContext = (tab: Tab): MatchContextAction => ({
+export const matchContext = (tab: TabWithURL): MatchContextAction => ({
   type: MATCH_CONTEXT,
   meta: { tab }
 });
@@ -65,10 +68,13 @@ export const CONTEXT_TRIGGERED = 'LMEM/CONTEXT_TRIGGERED';
 export interface ContextTriggeredAction extends TabAction {
   type: typeof CONTEXT_TRIGGERED;
   payload: MatchingContext[];
+  meta: TabMeta & {
+    tab: TabWithURL;
+  };
 }
 export const contextTriggered = (
   triggeredContexts: MatchingContext[],
-  tab: Tab
+  tab: TabWithURL
 ): ContextTriggeredAction => ({
   type: CONTEXT_TRIGGERED,
   payload: triggeredContexts,

--- a/src/app/background/sagas/lib/sendToTab.saga.ts
+++ b/src/app/background/sagas/lib/sendToTab.saga.ts
@@ -32,7 +32,12 @@ function* trySendToTab(
 }
 
 function* sendToTabSaga(tab: Tab, action: AppAction) {
-  if (!isAuthorizedTab(tab)) return;
+  if (!isAuthorizedTab(tab)) {
+    Logger.debug(
+      `${action.type} wasn't sent to ${tab.id}(${tab.url}) because the tab is not authorized.`
+    );
+    return;
+  }
 
   yield trySendToTab(tab, action, MAX_RETRIES);
 }

--- a/src/app/background/sagas/tab.ts
+++ b/src/app/background/sagas/tab.ts
@@ -43,11 +43,14 @@ import serviceMessageSaga from './serviceMessage.saga';
 import { getNbSubscriptions } from '../selectors/subscriptions.selectors';
 import { createCallAndRetry } from '../../sagas/effects/callAndRetry';
 import { Level } from '../../utils/Logger';
+import { TabWithURL } from 'app/lmem/tab';
+import { getTabById } from '../selectors/tabs';
 
 export function* tabSaga({ meta: { tab } }: TabAction) {
   const tabAuthorized = yield select(isTabAuthorized(tab));
   if (tabAuthorized) {
-    yield put(matchContext(tab));
+    // if the tab is authorized, it has an URL
+    yield put(matchContext(tab as TabWithURL));
   } else {
     yield call(disable, tab);
     yield call(resetBadge, tab.id);
@@ -148,7 +151,8 @@ export const contextNotTriggeredSaga = function*({
 const shouldActionBeSentToTab = (action: AppAction) =>
   Boolean(action.meta && action.meta.sendToTab);
 function* sendActionToTab(action: TabAction) {
-  yield sendToTabSaga(action.meta.tab, action);
+  const tab = yield select(getTabById(action.meta.tab.id));
+  yield sendToTabSaga(tab, action);
 }
 
 export default function* tabRootSaga() {

--- a/src/app/lmem/tab.ts
+++ b/src/app/lmem/tab.ts
@@ -1,9 +1,13 @@
 export default interface Tab {
   id: number;
-  url: string;
+  url?: string;
   ready?: boolean;
   options?: boolean;
   notices?: number[];
+}
+
+export interface TabWithURL extends Tab {
+  url: string;
 }
 
 export const isOptionsTab = (tab: Tab) => Boolean(tab && tab.options === true);

--- a/src/webext/createBrowserActionListener.ts
+++ b/src/webext/createBrowserActionListener.ts
@@ -2,13 +2,14 @@ import { Action } from 'redux';
 import { browserActionClicked } from 'app/actions/browser';
 import { captureMessage } from 'app/utils/sentry';
 import { Severity } from '@sentry/types';
+import Tab from 'app/lmem/tab';
 
 type Emit = (action: Action) => void;
 
 const createBrowserActionListener = (emit: Emit) => {
   const handleClick = (tab: browser.tabs.Tab) => {
-    if (tab.id && tab.url) {
-      emit(browserActionClicked({ id: tab.id, url: tab.url }));
+    if (typeof tab.id !== 'undefined') {
+      emit(browserActionClicked(tab as Tab));
     } else {
       captureMessage(
         `Tab has no id (${tab.id}) or URL (${tab.url}).`,

--- a/test/app/actions.ts
+++ b/test/app/actions.ts
@@ -5,13 +5,13 @@ import { contextTriggered } from 'app/actions/tabs';
 import { noticeDisplayed, noticeIgnored } from 'app/actions/notices';
 import { MatchingContext } from '../../src/app/lmem/matchingContext';
 import { StatefulNotice } from '../../src/app/lmem/notice';
-import Tab from '../../src/app/lmem/tab';
+import { TabWithURL } from '../../src/app/lmem/tab';
 import { generateStatefulNotice } from 'test/fakers/generateNotice';
 
 const expect = chai.expect;
 chai.use(sinonChai);
 
-const tab: Tab = { id: 1, url: 'http://tests.menant-benjamin.fr/' };
+const tab: TabWithURL = { id: 1, url: 'http://tests.menant-benjamin.fr/' };
 
 const notice: StatefulNotice = generateStatefulNotice();
 


### PR DESCRIPTION
Since we remove the `activeTab` permission we lost access to the tab URL in some part of the browser API.
We have a little hack to get the tab URL thus it may not be such an issue.
However it's not very future proof and from my point of view (maybe I missed something but) the `activeTab` tab permission seems relevant in our case.

Here, my implementation choice assumes a tab may not have an URL.