### PR TITLE
Fix/restablish active tab permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For the latest production version of **Dismoi** extension visit the official add
 
 The **Dismoi** extension requires the following permissions :
 
+- `activeTab` The extension is able to follow your navigation on the active tab, when you browse to a new `URL` you may receive a new information.
 - `storage` The extension use the [`sync` storage area](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync) to store and sync across browser instance the following informations :
   - `prefs` The contributions you dismissed, disliked, liked, read. Also if you accepted the :fr: [Term of Service](https://www.dismoi.io/cgu/).
   - `subscriptions` Which informers you are following.
@@ -129,7 +130,7 @@ It is automatically deployed to https://storybook.lmem.net on every `develop` br
 >
 > This program is distributed in the hope that it will be useful,
 > but WITHOUT ANY WARRANTY; without even the implied warranty of
-> MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+> MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
 > GNU AFFERO GENERAL PUBLIC LICENSE for more details.
 >
 > You should have received a copy of the GNU General Public License

--- a/manifest/base.js
+++ b/manifest/base.js
@@ -53,6 +53,6 @@ module.exports = Object.freeze({
     },
     default_title: 'Dismoi'
   },
-  permissions: ['storage'],
-  web_accessible_resources: ['img/*', 'fonts/*']
+  permissions: ['activeTab', 'storage'],
+  web_accessible_resources: ['img/*', 'fonts/*'],
 });

--- a/src/app/actions/tabs.ts
+++ b/src/app/actions/tabs.ts
@@ -1,8 +1,8 @@
 import { InstallationDetails } from 'app/lmem/installation';
 import { MatchingContext } from 'app/lmem/matchingContext';
-import Tab, { TabWithURL } from 'app/lmem/tab';
+import Tab from 'app/lmem/tab';
 import { ReceivedAction } from 'webext/createMessageHandler';
-import { BaseAction, TabAction, TabErrorAction, TabMeta } from '.';
+import { BaseAction, TabAction, TabErrorAction } from '.';
 import { Level } from '../utils/Logger';
 
 export const INIT = 'INIT';
@@ -41,11 +41,8 @@ export const navigatedToUrl = (url: string): NavigatedToUrlAction => ({
 export const MATCH_CONTEXT = 'LMEM/MATCH_CONTEXT';
 export interface MatchContextAction extends TabAction {
   type: typeof MATCH_CONTEXT;
-  meta: TabMeta & {
-    tab: TabWithURL;
-  };
 }
-export const matchContext = (tab: TabWithURL): MatchContextAction => ({
+export const matchContext = (tab: Tab): MatchContextAction => ({
   type: MATCH_CONTEXT,
   meta: { tab }
 });
@@ -68,13 +65,10 @@ export const CONTEXT_TRIGGERED = 'LMEM/CONTEXT_TRIGGERED';
 export interface ContextTriggeredAction extends TabAction {
   type: typeof CONTEXT_TRIGGERED;
   payload: MatchingContext[];
-  meta: TabMeta & {
-    tab: TabWithURL;
-  };
 }
 export const contextTriggered = (
   triggeredContexts: MatchingContext[],
-  tab: TabWithURL
+  tab: Tab
 ): ContextTriggeredAction => ({
   type: CONTEXT_TRIGGERED,
   payload: triggeredContexts,

--- a/src/app/background/sagas/lib/sendToTab.saga.ts
+++ b/src/app/background/sagas/lib/sendToTab.saga.ts
@@ -32,12 +32,7 @@ function* trySendToTab(
 }
 
 function* sendToTabSaga(tab: Tab, action: AppAction) {
-  if (!isAuthorizedTab(tab)) {
-    Logger.debug(
-      `${action.type} wasn't sent to ${tab.id}(${tab.url}) because the tab is not authorized.`
-    );
-    return;
-  }
+  if (!isAuthorizedTab(tab)) return;
 
   yield trySendToTab(tab, action, MAX_RETRIES);
 }

--- a/src/app/background/sagas/tab.ts
+++ b/src/app/background/sagas/tab.ts
@@ -43,14 +43,11 @@ import serviceMessageSaga from './serviceMessage.saga';
 import { getNbSubscriptions } from '../selectors/subscriptions.selectors';
 import { createCallAndRetry } from '../../sagas/effects/callAndRetry';
 import { Level } from '../../utils/Logger';
-import { TabWithURL } from 'app/lmem/tab';
-import { getTabById } from '../selectors/tabs';
 
 export function* tabSaga({ meta: { tab } }: TabAction) {
   const tabAuthorized = yield select(isTabAuthorized(tab));
   if (tabAuthorized) {
-    // if the tab is authorized, it has an URL
-    yield put(matchContext(tab as TabWithURL));
+    yield put(matchContext(tab));
   } else {
     yield call(disable, tab);
     yield call(resetBadge, tab.id);
@@ -151,8 +148,7 @@ export const contextNotTriggeredSaga = function*({
 const shouldActionBeSentToTab = (action: AppAction) =>
   Boolean(action.meta && action.meta.sendToTab);
 function* sendActionToTab(action: TabAction) {
-  const tab = yield select(getTabById(action.meta.tab.id));
-  yield sendToTabSaga(tab, action);
+  yield sendToTabSaga(action.meta.tab, action);
 }
 
 export default function* tabRootSaga() {

--- a/src/app/lmem/tab.ts
+++ b/src/app/lmem/tab.ts
@@ -1,13 +1,9 @@
 export default interface Tab {
   id: number;
-  url?: string;
+  url: string;
   ready?: boolean;
   options?: boolean;
   notices?: number[];
-}
-
-export interface TabWithURL extends Tab {
-  url: string;
 }
 
 export const isOptionsTab = (tab: Tab) => Boolean(tab && tab.options === true);

--- a/src/webext/createBrowserActionListener.ts
+++ b/src/webext/createBrowserActionListener.ts
@@ -2,14 +2,13 @@ import { Action } from 'redux';
 import { browserActionClicked } from 'app/actions/browser';
 import { captureMessage } from 'app/utils/sentry';
 import { Severity } from '@sentry/types';
-import Tab from 'app/lmem/tab';
 
 type Emit = (action: Action) => void;
 
 const createBrowserActionListener = (emit: Emit) => {
   const handleClick = (tab: browser.tabs.Tab) => {
-    if (typeof tab.id !== 'undefined') {
-      emit(browserActionClicked(tab as Tab));
+    if (tab.id && tab.url) {
+      emit(browserActionClicked({ id: tab.id, url: tab.url }));
     } else {
       captureMessage(
         `Tab has no id (${tab.id}) or URL (${tab.url}).`,

--- a/test/app/actions.ts
+++ b/test/app/actions.ts
@@ -5,13 +5,13 @@ import { contextTriggered } from 'app/actions/tabs';
 import { noticeDisplayed, noticeIgnored } from 'app/actions/notices';
 import { MatchingContext } from '../../src/app/lmem/matchingContext';
 import { StatefulNotice } from '../../src/app/lmem/notice';
-import { TabWithURL } from '../../src/app/lmem/tab';
+import Tab from '../../src/app/lmem/tab';
 import { generateStatefulNotice } from 'test/fakers/generateNotice';
 
 const expect = chai.expect;
 chai.use(sinonChai);
 
-const tab: TabWithURL = { id: 1, url: 'http://tests.menant-benjamin.fr/' };
+const tab: Tab = { id: 1, url: 'http://tests.menant-benjamin.fr/' };
 
 const notice: StatefulNotice = generateStatefulNotice();
 


### PR DESCRIPTION
@MaartenLMEM decided to restablish the `activeTab` permission, since :
 - Google Web Store approved our usage
 - We might need more power on active tab manipulation later
 - We still have bugs without it, mainly with missing `url information

I’ll merge this now so that we can play with the staging extension on monday, hopefully, but of course we can (should?) discuss this further nonetheless

This is only a revert of 2 commits.