### PR TITLE
fix: use meta URL in ratings actions instead of tabs.query

### DIFF
--- a/src/api/postRating.ts
+++ b/src/api/postRating.ts
@@ -4,7 +4,7 @@ import { post } from './call';
 export interface Rating {
   noticeId: number;
   rating: RatingType;
-  url?: string;
+  url: string;
   geolocation?: string;
 }
 

--- a/src/app/actions/index.ts
+++ b/src/app/actions/index.ts
@@ -144,6 +144,10 @@ export interface ActionMeta {
   tab?: Tab;
 }
 
+export interface ActionMetaWithTab extends ActionMeta {
+  tab: Tab;
+}
+
 export interface ActionMetaWithSeverity extends ActionMeta {
   severity: Level;
 }

--- a/src/app/actions/notices.ts
+++ b/src/app/actions/notices.ts
@@ -5,8 +5,15 @@ import {
   StatefulNotice
 } from 'app/lmem/notice';
 import Tab from 'app/lmem/tab';
-import { ActionMeta, BaseAction, ErrorAction, TabAction } from '.';
+import {
+  ActionMeta,
+  ActionMetaWithTab,
+  BaseAction,
+  ErrorAction,
+  TabAction
+} from '.';
 import { createErrorAction } from './helpers';
+import { ReceivedAction } from '../../webext/createMessageHandler';
 
 export const FETCH_NOTICES_REQUEST = 'NOTICES/FETCH_REQUEST';
 export interface FetchNoticesRequestAction extends BaseAction {
@@ -111,7 +118,10 @@ export const FEEDBACK_ON_NOTICE = 'FEEDBACK_ON_NOTICE';
 export interface FeedbackOnNoticeAction extends BaseAction {
   type: typeof FEEDBACK_ON_NOTICE;
   payload: { id: number; feedback: FeedbackType };
+  meta: ActionMeta;
 }
+export type ReceivedFeedbackOnNoticeAction = ReceivedAction &
+  FeedbackOnNoticeAction;
 
 export const createFeedbackOnNoticeAction = (
   id: number,
@@ -150,18 +160,22 @@ export const NOTICE_UNFOLDED = 'NOTICE/UNFOLDED';
 export interface UnfoldNoticeAction extends BaseAction {
   type: typeof NOTICE_UNFOLDED;
   payload: number;
+  meta: ActionMeta;
 }
 
 export const unfoldNotice = (id: number): UnfoldNoticeAction => ({
   type: NOTICE_UNFOLDED,
   payload: id,
-  meta: { sendToBackground: true }
+  meta: {
+    sendToBackground: true
+  }
 });
 
 export const MARK_NOTICE_READ = 'MARK_NOTICE_READ';
 export interface MarkNoticeReadAction extends BaseAction {
   type: typeof MARK_NOTICE_READ;
   payload: number;
+  meta?: ActionMeta;
 }
 
 export const markNoticeRead = (
@@ -177,10 +191,10 @@ export const NOTICE_BADGED = 'NOTICE/BADGED';
 export interface NoticeBadgedAction extends BaseAction {
   type: typeof NOTICE_BADGED;
   payload: number;
-  meta: { tab?: Tab };
+  meta: ActionMetaWithTab;
 }
 
-export const noticeBadged = (id: number, tab?: Tab): NoticeBadgedAction => ({
+export const noticeBadged = (id: number, tab: Tab): NoticeBadgedAction => ({
   type: NOTICE_BADGED,
   payload: id,
   meta: { tab }
@@ -189,15 +203,20 @@ export const noticeBadged = (id: number, tab?: Tab): NoticeBadgedAction => ({
 export const OUTBOUND_LINK_CLICKED = 'NOTICE/OUTBOUND_LINK_CLICKED';
 export interface OutboundLinkClickedAction extends BaseAction {
   type: typeof OUTBOUND_LINK_CLICKED;
-  payload: number;
-  meta: ActionMeta & { url?: string };
+  payload: { id: number; clickedUrl: string };
+  meta: ActionMeta;
 }
+export type ReceivedOutboundLinkClickedAction = ReceivedAction &
+  OutboundLinkClickedAction;
 
 export const outboundLinkClicked = (
   id: number,
-  url?: string
+  clickedUrl: string
 ): OutboundLinkClickedAction => ({
   type: OUTBOUND_LINK_CLICKED,
-  payload: id,
-  meta: { sendToBackground: true, url }
+  payload: {
+    id,
+    clickedUrl
+  },
+  meta: { sendToBackground: true }
 });

--- a/src/app/background/reducers/tabs.reducer.ts
+++ b/src/app/background/reducers/tabs.reducer.ts
@@ -1,18 +1,18 @@
 import * as R from 'ramda';
 import Tab from 'app/lmem/tab';
 import {
-  NAVIGATED_TO_URL,
-  TAB_REMOVED,
-  TAB_DIED,
-  LISTENING_ACTIONS_READY,
-  OPTIONS_TAB_OPENED,
-  NO_NOTICES_DISPLAYED,
-  CONTEXT_NOT_TRIGGERED,
-  NOTICES_FOUND,
   AppAction,
+  CONTEXT_NOT_TRIGGERED,
+  LISTENING_ACTIONS_READY,
+  NAVIGATED_TO_URL,
+  NO_NOTICES_DISPLAYED,
+  NOTICES_FOUND,
+  NoticesFoundAction,
+  OPTIONS_TAB_OPENED,
   ReceivedNavigatedToUrlAction,
   ReceivedTabRemovedAction,
-  NoticesFoundAction
+  TAB_DIED,
+  TAB_REMOVED
 } from 'app/actions';
 import { StatefulNotice } from 'app/lmem/notice';
 
@@ -50,12 +50,13 @@ export default function(state = initialState, action: AppAction) {
         state
       );
     case LISTENING_ACTIONS_READY:
-      return action.meta.tab
+      const tab = action.meta.tab as Tab;
+      return tab
         ? R.pipe(
-            addOrUpdateTab(action.meta.tab),
-            markTabReady(action.meta.tab),
-            action.meta.from === 'options' && action.meta.tab
-              ? markTabAsOptions(action.meta.tab)
+            addOrUpdateTab(tab),
+            markTabReady(tab),
+            action.meta.from === 'options' && tab
+              ? markTabAsOptions(tab)
               : R.identity
           )(state)
         : state;

--- a/src/app/background/sagas/tracking/trackNotice.saga.ts
+++ b/src/app/background/sagas/tracking/trackNotice.saga.ts
@@ -1,15 +1,15 @@
 import { SagaIterator } from '@redux-saga/types';
-import { call, select, put } from '@redux-saga/core/effects';
+import { call, put, select } from '@redux-saga/core/effects';
 import Tracker from 'types/Tracker';
 import truncate from 'app/utils/truncate';
 import { stripHtml } from 'app/utils/stripHtml';
 import {
   FeedbackOnNoticeAction,
   getURLFromActionMeta,
+  NoticeBadgedAction,
   NoticeDisplayedAction,
-  OutboundLinkClickedAction,
-  UnfoldNoticeAction,
-  NoticeBadgedAction
+  ReceivedOutboundLinkClickedAction,
+  UnfoldNoticeAction
 } from 'app/actions';
 import { createErrorAction } from 'app/actions/helpers';
 import {
@@ -94,11 +94,11 @@ export const trackNoticeFeedbackSaga = (tracker: Tracker) =>
   };
 
 export const trackNoticeOutboundClickSaga = (tracker: Tracker) =>
-  function*(action: OutboundLinkClickedAction): SagaIterator {
+  function*(action: ReceivedOutboundLinkClickedAction): SagaIterator {
     try {
-      if (action.meta.url) {
+      if (action.meta.tab.url) {
         yield call(tracker.trackOutboundLink, {
-          url: action.meta.url
+          url: action.meta.tab.url
         });
       }
     } catch (e) {

--- a/src/app/content/sagas/notices.ts
+++ b/src/app/content/sagas/notices.ts
@@ -46,7 +46,9 @@ function* markNoticeReadSaga(unfoldNoticeAction: UnfoldNoticeAction) {
   );
   if (!unfoldedNotice.state.read) {
     yield put(
-      markNoticeRead(unfoldNoticeAction.payload, { sendToBackground: true })
+      markNoticeRead(unfoldNoticeAction.payload, {
+        sendToBackground: true
+      })
     );
   }
 }

--- a/src/components/organisms/Notice/Notice.tsx
+++ b/src/components/organisms/Notice/Notice.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import { stripHtml } from 'app/utils/stripHtml';
-import { Contributor, Button, Timer, CenterContainer } from 'components/atoms';
+import { Button, CenterContainer, Contributor, Timer } from 'components/atoms';
 import InteractiveAvatar from 'components/molecules/InteractiveAvatar';
 import Container, { height, marginBottom } from './Container';
 import Content from './Content';

--- a/src/components/organisms/NoticeDetails/NoticeDetails.tsx
+++ b/src/components/organisms/NoticeDetails/NoticeDetails.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, MouseEvent } from 'react';
+import React, { MouseEvent, PureComponent } from 'react';
 import styled from 'styled-components';
 import { format } from 'date-fns';
 import ThumbUp from 'components/atoms/icons/ThumbUp';
@@ -68,7 +68,7 @@ export interface NoticeDetailsMethodsProps {
   confirmDislike: (id: number) => void;
   undislike: (id: number) => void;
   view?: (id: number) => void;
-  outboundLinkClicked?: (id: number, url?: string) => void;
+  outboundLinkClicked?: (id: number, clickedUrl: string) => void;
   goBack: () => void;
   clickContributor: (id: number) => void;
 }
@@ -158,7 +158,7 @@ class NoticeDetails extends PureComponent<NoticeDetailsProps, CountDownState> {
       if ((e.target as HTMLElement).tagName.toLowerCase() === 'a') {
         outboundLinkClicked(
           id,
-          (e.target as HTMLElement).getAttribute('href') || undefined
+          (e.target as HTMLElement).getAttribute('href') as string
         );
       }
     }

--- a/src/webext/getSelectedTab.ts
+++ b/src/webext/getSelectedTab.ts
@@ -1,6 +1,0 @@
-const getSelectedTab = () =>
-  browser.tabs
-    .query({ active: true, currentWindow: true })
-    .then(([selectedTab]) => selectedTab);
-
-export default getSelectedTab;


### PR DESCRIPTION
This PR aims to solve this :

![image](https://user-images.githubusercontent.com/3037833/88477392-ddd78600-cf3f-11ea-8347-78e6e8090590.png)

@MaartenLMEM I got it wrong : This particular issue exists with or without `activeTab` permission (reproduced locally). 

This is a serious issue, despite its relation to notices ratings, because the failure breaks the whole background script, freezing the extension until browser reload.

The change here is to stop using the `tabs.query` (which usage I forgot to mention in my [forum post](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/zs8CFXLORhs)) and use instead the true tab that sent the event.

It also makes more sense functionally to use the action metadata to know where the event occured than trying to detect it afterward based on the current active tab, which may have changed between the actual event and the rating saga handling.

@lutangar I’m merging this immediately because current staging is broken, and it’s seems to be working fine with this (I’ve tried to play some time with it to ensure stability), but this fix remains of course open to discussion, and to better fix if so.