### PR TITLE
fix: set fetch to use CORS mode

### DIFF
--- a/src/api/call.ts
+++ b/src/api/call.ts
@@ -26,7 +26,7 @@ const buildQueryString: BuildQueryString = R.pipe(
 export const get = (path: string, data: object = {}) => {
   const endpoint = path.startsWith('http') ? path : BACKEND_ORIGIN + path;
   const queryString = R.isEmpty(data) ? '' : buildQueryString(data);
-  return fetch(`${endpoint}${queryString}`).then(response => {
+  return fetch(`${endpoint}${queryString}`, { mode: 'cors' }).then(response => {
     if (response.status >= 400) {
       throw new APIStatusCodeError(response);
     }
@@ -37,6 +37,7 @@ export const get = (path: string, data: object = {}) => {
 export const post = (path: string, data: {} | []) =>
   fetch(path.startsWith('http') ? path : BACKEND_ORIGIN + path, {
     method: 'POST',
+    mode: 'cors',
     headers: {
       'Content-Type': 'application/json'
     },

--- a/src/app/profiles/store/sagas/contributors.saga.ts
+++ b/src/app/profiles/store/sagas/contributors.saga.ts
@@ -2,6 +2,6 @@ import { takeLatest } from 'redux-saga/effects';
 import { REFRESH_CONTRIBUTORS } from 'app/actions';
 import refreshContributorsSaga from 'app/store/sagas/refreshContributors.saga';
 
-export default function* matchingContextsRootSaga() {
+export default function* contributorsSaga() {
   yield takeLatest(REFRESH_CONTRIBUTORS, refreshContributorsSaga);
 }


### PR DESCRIPTION
I’m trying this because I noticed that under some circumstances, the profiles app does not include the `Origin` when fetching the API. It may be because it’s only a GET (`/contributors`), but then it complains that it does not have a access-control-allow-origin …