### PR TITLE
fix(banner): Fix default banner not showing up.

### DIFF
--- a/webpack.profiles.config.js
+++ b/webpack.profiles.config.js
@@ -38,16 +38,16 @@ module.exports = function webpack(env = {}, argv = {}) {
         ...defaultWebpackConfig.module.rules,
         {
           test: /\.(png|jpe?g|gif)$/i,
+          include: path.resolve(__dirname, '..', 'src/app/profiles'),
           loader: 'file-loader',
           options: {
             publicPath: process.env.PROFILES_ASSETS_PATH,
             name: '[path][name].[ext]',
             context: 'src/assets',
-          },
+          }
         },
       ]
     },
-
     entry: [
       'core-js/stable',
       'regenerator-runtime/runtime',


### PR DESCRIPTION
Default image rule and the profile one were someway conflicting, explicitly include profiles app directory does fix an issue with the image being corrupted.