### PR TITLE
fix: profiles crashes because featured notices does not have relayersIds

### DIFF
--- a/src/api/fetchNotice.ts
+++ b/src/api/fetchNotice.ts
@@ -1,12 +1,19 @@
-import { Notice } from 'app/lmem/notice';
+import {
+  NoticeWithContributor,
+  NoticeWithContributorId
+} from 'app/lmem/notice';
 import { CONTRIBUTOR_NOTICES_BY_PAGE } from 'app/profiles/store/sagas/notices.saga';
 import { get } from './call';
 
-export const fetchNotice = (noticeUrl: string): Promise<Notice> =>
-  get(noticeUrl);
+export const fetchNotice = (
+  noticeUrl: string
+): Promise<NoticeWithContributor> => get(noticeUrl);
 
-export const fetchNoticesByUrls = (noticeUrls: string[]): Promise<Notice[]> =>
-  Promise.all(noticeUrls.map(fetchNotice));
+export const fetchNoticesByUrls = (
+  noticeUrls: string[]
+): Promise<NoticeWithContributor[]> => Promise.all(noticeUrls.map(fetchNotice));
 
-export const fetchNotices = (data: object = {}): Promise<Notice[]> =>
+export const fetchNotices = (
+  data: object = {}
+): Promise<NoticeWithContributorId[]> =>
   get('notices', { limit: CONTRIBUTOR_NOTICES_BY_PAGE, offset: 0, ...data });

--- a/src/app/actions/notices.ts
+++ b/src/app/actions/notices.ts
@@ -2,7 +2,8 @@ import {
   getIgnoringReason,
   IgnoringReason,
   Notice,
-  StatefulNotice
+  StatefulNotice,
+  StatefulNoticeWithContributor
 } from 'app/lmem/notice';
 import Tab from 'app/lmem/tab';
 import {
@@ -95,12 +96,12 @@ export const NOTICES_FOUND = 'NOTICES_FOUND';
 export interface NoticesFoundAction extends TabAction {
   type: typeof NOTICES_FOUND;
   payload: {
-    notices: StatefulNotice[];
+    notices: StatefulNoticeWithContributor[];
   };
 }
 
 export const noticesFound = (
-  notices: StatefulNotice[],
+  notices: StatefulNoticeWithContributor[],
   tab: Tab
 ): NoticesFoundAction => ({
   type: NOTICES_FOUND,

--- a/src/app/background/reducers/resources/index.ts
+++ b/src/app/background/reducers/resources/index.ts
@@ -5,7 +5,7 @@ import notices from './notices.reducer';
 import restrictedContexts from './restrictedContexts.reducer';
 import { Contributor } from 'app/lmem/contributor';
 import { MatchingContext, RestrictedContext } from 'app/lmem/matchingContext';
-import { Notice } from 'app/lmem/notice';
+import { NoticeWithContributor } from 'app/lmem/notice';
 
 export interface StateWithContributors {
   contributors: Contributor[];
@@ -14,7 +14,7 @@ export interface StateWithContributors {
 export interface ResourcesState extends StateWithContributors {
   matchingContexts: MatchingContext[];
   restrictedContexts: RestrictedContext[];
-  notices: Notice[];
+  notices: NoticeWithContributor[];
 }
 
 export default combineReducers({

--- a/src/app/background/reducers/resources/notices.reducer.ts
+++ b/src/app/background/reducers/resources/notices.reducer.ts
@@ -1,12 +1,15 @@
 import * as R from 'ramda';
 import { AppAction, NOTICES_FETCHED } from 'app/actions';
-import { Notice } from 'app/lmem/notice';
+import { NoticeWithContributor } from 'app/lmem/notice';
 
-export type Notices = Notice[];
+type NoticesWithContributor = NoticeWithContributor[];
 
-export const initialState: Notices = [];
+export const initialState: NoticesWithContributor = [];
 
-export default (state: Notices = initialState, action: AppAction) => {
+export default (
+  state: NoticesWithContributor = initialState,
+  action: AppAction
+) => {
   switch (action.type) {
     case NOTICES_FETCHED:
       return R.uniqWith(R.eqProps('id'), R.concat(state, action.payload));

--- a/src/app/background/reducers/tabs.reducer.ts
+++ b/src/app/background/reducers/tabs.reducer.ts
@@ -14,13 +14,13 @@ import {
   TAB_DIED,
   TAB_REMOVED
 } from 'app/actions';
-import { StatefulNotice } from 'app/lmem/notice';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 
 export interface TabsState {
   [tabId: string]: Tab;
 }
 
-export const toNoticesIds = (notices: StatefulNotice[]) =>
+export const toNoticesIds = (notices: StatefulNoticeWithContributor[]) =>
   notices.map(({ id }) => id);
 
 export const initialState: TabsState = {};

--- a/src/app/background/selectors/prefs.ts
+++ b/src/app/background/selectors/prefs.ts
@@ -1,9 +1,9 @@
 import { createSelector } from 'reselect';
 import {
-  Notice,
-  StatefulNotice,
+  NoticeWithContributor,
   isIgnored,
-  shouldNoticeBeShown
+  shouldNoticeBeShown,
+  StatefulNoticeWithContributor
 } from 'app/lmem/notice';
 import { BackgroundState } from '../reducers';
 
@@ -28,7 +28,7 @@ export const getAddStateToNotice = (state: BackgroundState) => {
   const disliked = getDisliked(state);
   const read = getRead(state);
 
-  return (notice: Notice): StatefulNotice => ({
+  return (notice: NoticeWithContributor): StatefulNoticeWithContributor => ({
     ...notice,
     state: {
       dismissed: dismissed.includes(notice.id),
@@ -39,19 +39,19 @@ export const getAddStateToNotice = (state: BackgroundState) => {
   });
 };
 
-export const getNoticesToDisplay = (notices: Notice[]) => (
+export const getNoticesToDisplay = (notices: NoticeWithContributor[]) => (
   state: BackgroundState
-): StatefulNotice[] =>
+): StatefulNoticeWithContributor[] =>
   notices.map(getAddStateToNotice(state)).filter(shouldNoticeBeShown);
 
-export const getDismissedNotices = (notices: Notice[]) => (
+export const getDismissedNotices = (notices: NoticeWithContributor[]) => (
   state: BackgroundState
-): StatefulNotice[] =>
+): StatefulNoticeWithContributor[] =>
   notices
     .map(getAddStateToNotice(state))
     .filter(notice => notice.state.dismissed);
 
-export const getIgnoredNotices = (notices: Notice[]) => (
+export const getIgnoredNotices = (notices: NoticeWithContributor[]) => (
   state: BackgroundState
-): StatefulNotice[] =>
+): StatefulNoticeWithContributor[] =>
   notices.map(getAddStateToNotice(state)).filter(isIgnored);

--- a/src/app/content/App/Notice/Details/index.tsx
+++ b/src/app/content/App/Notice/Details/index.tsx
@@ -4,12 +4,12 @@ import withTitle from 'app/hocs/withTitle';
 import NoticeDetails, {
   NoticeDetailsMethodsProps
 } from 'components/organisms/NoticeDetails/NoticeDetails';
-import { StatefulNotice } from 'app/lmem/notice';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 import { Contributor } from 'app/lmem/contributor';
 import withConnect from './withConnect';
 
 export interface DetailsScreenDataProps {
-  notice?: StatefulNotice;
+  notice?: StatefulNoticeWithContributor;
   relayed?: boolean;
   relayer?: Contributor;
 }

--- a/src/app/content/App/Notice/List/index.tsx
+++ b/src/app/content/App/Notice/List/index.tsx
@@ -8,11 +8,11 @@ import NoticeItem, {
   transitionKeys
 } from 'components/organisms/Notice/Notice';
 import ListContainer from './ListContainer';
-import { StatefulNotice } from 'app/lmem/notice';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 import withConnect from './withConnect';
 
 export interface Props {
-  notices: StatefulNotice[];
+  notices: StatefulNoticeWithContributor[];
   dismiss: (id: number) => void;
   confirmDismiss: (id: number) => void;
   undismiss: (id: number) => void;

--- a/src/app/content/reducers/notices.ts
+++ b/src/app/content/reducers/notices.ts
@@ -10,7 +10,7 @@ import {
   markNoticeRead,
   confirmDismissNotice,
   confirmDislikeNotice,
-  StatefulNotice
+  StatefulNoticeWithContributor
 } from 'app/lmem/notice';
 import {
   FEEDBACK_ON_NOTICE,
@@ -22,7 +22,7 @@ import {
   UNSUBSCRIBE
 } from 'app/actions';
 
-export type NoticesState = StatefulNotice[];
+export type NoticesState = StatefulNoticeWithContributor[];
 
 export default (state: NoticesState = [], action: AppAction): NoticesState => {
   switch (action.type) {

--- a/src/app/lmem/notice.ts
+++ b/src/app/lmem/notice.ts
@@ -16,15 +16,17 @@ export interface BaseNotice {
   screenshot?: string;
 }
 
-export interface Notice extends BaseNotice {
+export interface NoticeWithContributor extends BaseNotice {
   contributor: Contributor;
   relayers: Contributor[];
 }
 
-export interface NoticeItem extends BaseNotice {
+export interface NoticeWithContributorId extends BaseNotice {
   contributorId: ContributorId;
   relayersIds: ContributorId[];
 }
+
+export type Notice = NoticeWithContributorId | NoticeWithContributor;
 
 export interface Contribution {
   url: string;
@@ -43,9 +45,16 @@ export interface NoticeState {
   justDismissed?: boolean;
 }
 
-export interface StatefulNotice extends Notice {
+export type StatefulNoticeWithContributor = NoticeWithContributor & {
   state: NoticeState;
-}
+};
+export type StatefulNoticeWithContributorId = NoticeWithContributorId & {
+  state: NoticeState;
+};
+
+export type StatefulNotice =
+  | StatefulNoticeWithContributor
+  | StatefulNoticeWithContributorId;
 
 export enum NoticeFeedbackType {
   DISMISS = 'dismiss',
@@ -65,7 +74,7 @@ export const isIgnored = (notice: StatefulNotice): boolean =>
 export const getIgnoringReason = (notice: StatefulNotice): IgnoringReason =>
   notice.state.dismissed ? 'dismiss' : 'dislike';
 
-export const dismissNotice = (notice: StatefulNotice): StatefulNotice => ({
+export const dismissNotice = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   state: {
     ...notice.state,
@@ -74,9 +83,9 @@ export const dismissNotice = (notice: StatefulNotice): StatefulNotice => ({
   }
 });
 
-export const confirmDismissNotice = (
-  notice: StatefulNotice
-): StatefulNotice => ({
+export const confirmDismissNotice = <N extends StatefulNotice>(
+  notice: N
+): N => ({
   ...notice,
   state: {
     ...notice.state,
@@ -84,7 +93,7 @@ export const confirmDismissNotice = (
   }
 });
 
-export const undismissNotice = (notice: StatefulNotice): StatefulNotice => ({
+export const undismissNotice = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   state: {
     ...notice.state,
@@ -96,7 +105,7 @@ export const undismissNotice = (notice: StatefulNotice): StatefulNotice => ({
 export const incrementRating = (rating?: number) => (rating || 0) + 1;
 export const decrementRating = (rating?: number) => (!rating ? 0 : rating - 1);
 
-export const likeNotice = (notice: StatefulNotice): StatefulNotice => ({
+export const likeNotice = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   ratings: {
     ...notice.ratings,
@@ -108,7 +117,7 @@ export const likeNotice = (notice: StatefulNotice): StatefulNotice => ({
     justLiked: true
   }
 });
-export const unlikeNotice = (notice: StatefulNotice): StatefulNotice => ({
+export const unlikeNotice = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   ratings: {
     ...notice.ratings,
@@ -120,7 +129,7 @@ export const unlikeNotice = (notice: StatefulNotice): StatefulNotice => ({
     justLiked: false
   }
 });
-export const dislikeNotice = (notice: StatefulNotice): StatefulNotice => ({
+export const dislikeNotice = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   ratings: {
     ...notice.ratings,
@@ -132,16 +141,16 @@ export const dislikeNotice = (notice: StatefulNotice): StatefulNotice => ({
     justDisliked: true
   }
 });
-export const confirmDislikeNotice = (
-  notice: StatefulNotice
-): StatefulNotice => ({
+export const confirmDislikeNotice = <N extends StatefulNotice>(
+  notice: N
+): N => ({
   ...notice,
   state: {
     ...notice.state,
     justDisliked: false
   }
 });
-export const undislikeNotice = (notice: StatefulNotice): StatefulNotice => ({
+export const undislikeNotice = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   ratings: {
     ...notice.ratings,
@@ -153,7 +162,7 @@ export const undislikeNotice = (notice: StatefulNotice): StatefulNotice => ({
     justDisliked: false
   }
 });
-export const markNoticeRead = (notice: StatefulNotice): StatefulNotice => ({
+export const markNoticeRead = <N extends StatefulNotice>(notice: N): N => ({
   ...notice,
   state: {
     ...notice.state,
@@ -161,14 +170,14 @@ export const markNoticeRead = (notice: StatefulNotice): StatefulNotice => ({
   }
 });
 
-export const getNotice = <N extends Notice>(
+export const getNotice = <N extends NoticeWithContributor>(
   id: number,
   notices: N[]
 ): N | undefined => find((notice: N): boolean => notice.id === id, notices);
 
 export const isNoticeValid = (notice: {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-}): notice is Notice => {
+}): notice is NoticeWithContributor => {
   if (Object(notice) !== notice) return false;
 
   const { contributor, message } = notice;
@@ -180,7 +189,7 @@ export const isNoticeValid = (notice: {
   );
 };
 
-export const warnIfNoticeInvalid = (notice: Notice): boolean => {
+export const warnIfNoticeInvalid = (notice: NoticeWithContributor): boolean => {
   const valid = isNoticeValid(notice);
 
   if (!valid) {

--- a/src/app/profiles/App/Profiles/Profile/Profile.tsx
+++ b/src/app/profiles/App/Profiles/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import React, { useState, MouseEvent } from 'react';
 import styled from 'styled-components';
 import { StatefulContributor } from 'app/lmem/contributor';
-import { Notice } from 'app/lmem/notice';
+import { NoticeWithContributor } from 'app/lmem/notice';
 import Error from '../../Error';
 import {
   Box,
@@ -132,8 +132,8 @@ const SidebarBoxWithAction = styled(SidebarBox)`
 export interface ProfileProps {
   contributor?: StatefulContributor;
   noticesLoading?: boolean;
-  notices: Notice[];
-  featuredNotice?: Notice;
+  notices: NoticeWithContributor[];
+  featuredNotice?: NoticeWithContributor;
   subscribe: () => void | undefined;
   unsubscribe: () => void | undefined;
   fetchMoreNotices: () => void | undefined;
@@ -193,7 +193,7 @@ export const Profile = ({
     }
   };
 
-  const handleSeeNoticeInContext = (notice?: Notice) => () => {
+  const handleSeeNoticeInContext = (notice?: NoticeWithContributor) => () => {
     if (connected) {
       if (contributor?.subscribed) {
         if (notice && notice.exampleUrl) {

--- a/src/app/profiles/App/Profiles/Profile/ProfileNoticeList.tsx
+++ b/src/app/profiles/App/Profiles/Profile/ProfileNoticeList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Notice } from 'app/lmem/notice';
+import { NoticeWithContributor } from 'app/lmem/notice';
 import ProfileNoticeListItem from './ProfileNoticeListItem';
 import { LoadingBig } from 'components/atoms/icons';
 import { CenterContainer, Link, LoadingRotator } from 'components/atoms';
@@ -9,8 +9,8 @@ const ProfileNoticeList = styled.section``;
 
 export interface ProfileNoticeListProps {
   loading?: boolean;
-  notices: Notice[];
-  seeNoticeInContext: (notice: Notice) => () => void;
+  notices: NoticeWithContributor[];
+  seeNoticeInContext: (notice: NoticeWithContributor) => () => void;
   fetchMoreNotices: () => void;
   fetchedAll: boolean;
 }

--- a/src/app/profiles/App/Profiles/Profile/ProfileNoticeListItem.tsx
+++ b/src/app/profiles/App/Profiles/Profile/ProfileNoticeListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { format } from 'date-fns';
 import { BorderButton, Box, LoadingRotator, Paragraph } from 'components/atoms';
-import { Notice } from 'app/lmem/notice';
+import { NoticeWithContributor } from 'app/lmem/notice';
 import { LoadingBig, Pin } from 'components/atoms/icons';
 import { stripUrlProtocol } from 'app/utils/stripUrlProtocol';
 
@@ -54,7 +54,7 @@ const NoticeBottomLine = styled.div`
 `;
 
 export interface ProfileNoticeListItemProps {
-  notice?: Notice;
+  notice?: NoticeWithContributor;
   loading?: boolean;
   seeInContext: () => void;
   className?: string;

--- a/src/app/profiles/store/reducers/notices.reducer.ts
+++ b/src/app/profiles/store/reducers/notices.reducer.ts
@@ -6,11 +6,11 @@ import {
   FETCH_NOTICES_REQUEST,
   NOTICES_FETCHED
 } from 'app/actions';
-import { NoticeItem } from 'app/lmem/notice';
+import { Notice } from 'app/lmem/notice';
 
-export type NoticesCollectionState = CollectionState<NoticeItem>;
+export type NoticesCollectionState = CollectionState<Notice>;
 
-export default createCollectionReducer<NoticeItem>(
+export default createCollectionReducer<Notice>(
   FETCH_NOTICES_REQUEST,
   NOTICES_FETCHED,
   FETCH_NOTICES_FAILURE,

--- a/src/app/profiles/store/selectors/index.ts
+++ b/src/app/profiles/store/selectors/index.ts
@@ -8,7 +8,7 @@ import {
   StatefulContributor
 } from 'app/lmem/contributor';
 import { Subscription, Subscriptions } from 'app/lmem/subscription';
-import { Notice, NoticeItem } from 'app/lmem/notice';
+import { Notice, NoticeWithContributor } from 'app/lmem/notice';
 import { makeGetRouteParam } from 'app/store/selectors';
 import { getContributors } from './contributors';
 import { getNotices as getNoticesItems, getNoticesCollection } from './notices';
@@ -64,17 +64,23 @@ export const getFeaturedNoticeId = createSelector(
 );
 
 export const enhanceNotice = (contributors: Contributor[]) => (
-  noticeItem: NoticeItem
-): Notice => ({
+  noticeItem: Notice
+): NoticeWithContributor => ({
   ...noticeItem,
-  relayers: noticeItem.relayersIds
-    .map(relayerId =>
-      contributors.find(contributor => relayerId === contributor.id)
-    )
-    .filter(RA.isNotNil) as Contributor[],
-  contributor: contributors.find(
-    contributor => noticeItem.contributorId === contributor.id
-  ) as Contributor
+  contributor:
+    'contributor' in noticeItem
+      ? noticeItem.contributor
+      : (contributors.find(
+          contributor => noticeItem.contributorId === contributor.id
+        ) as Contributor),
+  relayers:
+    'relayers' in noticeItem
+      ? noticeItem.relayers
+      : ((noticeItem.relayersIds || [])
+          .map((relayerId: ContributorId) =>
+            contributors.find(contributor => relayerId === contributor.id)
+          )
+          .filter(RA.isNotNil) as Contributor[])
 });
 
 export const getNotices = createSelector(

--- a/src/app/profiles/store/selectors/notices.ts
+++ b/src/app/profiles/store/selectors/notices.ts
@@ -4,14 +4,14 @@ import {
   getIndexedOffset,
   isCollectionLoading
 } from 'app/store/collection/selectors';
-import { NoticeItem } from 'app/lmem/notice';
+import { Notice } from 'app/lmem/notice';
 import { ContributorId } from 'app/lmem/contributor';
 
 export const getNoticesCollection = (state: ProfilesState) => state.notices;
 
 export const areNoticesLoading = createSelector(
   [getNoticesCollection],
-  noticesCollection => isCollectionLoading<NoticeItem>(noticesCollection)
+  noticesCollection => isCollectionLoading<Notice>(noticesCollection)
 );
 export const getNotices = createSelector(
   [getNoticesCollection],

--- a/src/components/organisms/Notice/Notice.tsx
+++ b/src/components/organisms/Notice/Notice.tsx
@@ -8,7 +8,7 @@ import Content from './Content';
 import Deleted from './Deleted';
 import DeleteButton from './DeleteButton';
 import Title from './Title';
-import { StatefulNotice } from 'app/lmem/notice';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 import {
   CountDownState,
   initialState as countdownInitialState
@@ -45,13 +45,13 @@ const ContributorName = styled(Contributor)`
 `;
 
 export interface NoticeTransitionProps {
-  item: StatefulNotice;
+  item: StatefulNoticeWithContributor;
   props: object;
   key: string;
 }
 
 interface Props {
-  notice: StatefulNotice;
+  notice: StatefulNoticeWithContributor;
   dismiss: (id: number) => void;
   confirmDismiss: (id: number) => void;
   undismiss: (id: number) => void;

--- a/src/components/organisms/NoticeDetails/NoticeDetails.tsx
+++ b/src/components/organisms/NoticeDetails/NoticeDetails.tsx
@@ -10,7 +10,7 @@ import {
   Timer
 } from 'components/atoms';
 import { Relay } from 'components/atoms/icons';
-import { StatefulNotice } from 'app/lmem/notice';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 import {
   CountDownState,
   initialState as countdownInitialState
@@ -86,7 +86,7 @@ const Relayer = styled(ContributorNotice)`
 `;
 
 export interface NoticeDetailsDataProps {
-  notice: StatefulNotice;
+  notice: StatefulNoticeWithContributor;
   relayer?: Contributor;
 }
 

--- a/test/fakers/generateNotice.ts
+++ b/test/fakers/generateNotice.ts
@@ -1,6 +1,6 @@
 import Faker from 'faker';
 import { subMonths, subWeeks } from 'date-fns';
-import { StatefulNotice } from 'app/lmem/notice';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 import { Contributor } from 'app/lmem/contributor';
 import { generateContributor } from './generateContributor';
 
@@ -34,7 +34,7 @@ export const generateStatefulNotice = ({
   dismissed,
   read,
   exampleUrl
-}: Options = {}): StatefulNotice => {
+}: Options = {}): StatefulNoticeWithContributor => {
   const id = Math.random() * 1000;
   return {
     id,
@@ -46,13 +46,13 @@ export const generateStatefulNotice = ({
     strippedMessage: strippedMessage || message || defaultMessage,
     ratings: { likes: likes || 42, dislikes: dislikes || 2 },
     contributor: contributor || generateContributor(),
+    relayers: [generateContributor()],
     visibility: 'public',
     state: {
       liked: Boolean(liked),
       dismissed: Boolean(dismissed),
       disliked: Boolean(disliked),
       read: Boolean(read)
-    },
-    relayers: [generateContributor()],
+    }
   };
 };


### PR DESCRIPTION
This commits clarifies between NoticeWithContributor and NoticeWithContributorId

Ideally, API should be consistent and always send relations Ids … (or GraphQL :-) ?)

Key (and fixing) change is in `src/app/profiles/store/selectors/index.ts`