### PR TITLE
feat: Add campaign param when redirecting to profiles for the first time

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "prettier-config-standard": "^1.0.1",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",
-    "query-string": "^6.9.0",
     "ramda": "^0.26.1",
     "ramda-adjunct": "^2.19.0",
     "react": "16.8.0",

--- a/src/app/actions/options.ts
+++ b/src/app/actions/options.ts
@@ -1,18 +1,25 @@
 import Tab from 'app/lmem/tab';
 import { BaseAction, ErrorAction } from './';
 import { Level } from '../utils/Logger';
+import { GetParams } from '../../api/call';
 
 export const OPTIONS_REQUESTED = 'OPTIONS_REQUESTED';
 export interface OptionsRequestedAction extends BaseAction {
   type: typeof OPTIONS_REQUESTED;
-  payload?: string;
+  payload: {
+    pathname?: string;
+    params?: GetParams;
+  };
 }
 
 export const optionsRequested = (
-  pathname?: string
+  payload: {
+    pathname?: string;
+    params?: GetParams;
+  } = {}
 ): OptionsRequestedAction => ({
   type: OPTIONS_REQUESTED,
-  payload: pathname,
+  payload,
   meta: {
     sendToBackground: true
   }

--- a/src/app/background/sagas/install.ts
+++ b/src/app/background/sagas/install.ts
@@ -33,7 +33,8 @@ export function* installedSaga({
 
     const { reason } = installedDetails;
     if (reason === 'install') {
-      yield put(optionsRequested());
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      yield put(optionsRequested({ params: { pk_campaign: 'installed' } }));
     }
   } catch (e) {
     captureException(e);

--- a/src/app/background/sagas/options.saga.ts
+++ b/src/app/background/sagas/options.saga.ts
@@ -9,10 +9,12 @@ import {
 } from 'app/actions';
 import { getOptionsTab } from '../selectors/tabs';
 
-function* openOptionsSaga({ payload: pathname }: OptionsRequestedAction) {
+function* openOptionsSaga({
+  payload: { pathname, params }
+}: OptionsRequestedAction) {
   try {
     let tab = yield select(getOptionsTab);
-    const url = getOptionsUrl(pathname);
+    const url = getOptionsUrl(pathname, params);
     if (tab) {
       const { index } = yield call(browser.tabs.get, tab.id);
       yield call(browser.tabs.highlight, {
@@ -25,7 +27,7 @@ function* openOptionsSaga({ payload: pathname }: OptionsRequestedAction) {
         });
       }
     } else {
-      tab = yield call(openOptions, pathname);
+      tab = yield call(openOptions, pathname, params);
     }
 
     if (tab && tab.id) {

--- a/src/app/background/sagas/serviceMessage.saga.ts
+++ b/src/app/background/sagas/serviceMessage.saga.ts
@@ -25,28 +25,14 @@ export default function* serviceMessageSaga(tab: Tab, nbNotices = 0) {
     const nbSubscriptions = yield select(getNbSubscriptions);
     const lastShownDate = yield select(getServiceMessageLastShowDate);
 
-    if (!tosAccepted) {
-      yield put(
-        showServiceMessage(
-          {
-            messages: buildMessages([], nbNotices),
-            action: {
-              label: 'Lire et accepter les CGU',
-              url: '/onboarding',
-              type: LinkType.Options
-            }
-          },
-          tab
-        )
-      );
-    } else if (tosAccepted && nbSubscriptions === 0) {
+    if (tosAccepted && nbSubscriptions === 0) {
       yield put(
         showServiceMessage(
           {
             messages: buildMessages([], nbNotices),
             action: {
               label: 'Choisir mes sources',
-              url: '/settings/suggestions',
+              url: '/sources',
               type: LinkType.Options
             }
           },

--- a/src/app/content/App/ServiceMessage/withConnect.ts
+++ b/src/app/content/App/ServiceMessage/withConnect.ts
@@ -14,7 +14,7 @@ const mapStateToProps = (state: ContentState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   openOnboarding: (pathname: string) => () =>
-    dispatch(optionsRequested(pathname))
+    dispatch(optionsRequested({ pathname }))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/src/app/content/actions/goToContributor.ts
+++ b/src/app/content/actions/goToContributor.ts
@@ -3,4 +3,4 @@ import pathToContributor from 'app/profiles/App/pathToContributor';
 import { Contributor } from 'app/lmem/contributor';
 
 export default (contributor: Contributor) =>
-  optionsRequested(pathToContributor(contributor));
+  optionsRequested({ pathname: pathToContributor(contributor) });

--- a/src/app/matomo.ts
+++ b/src/app/matomo.ts
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase, @typescript-eslint/camelcase */
-import queryString from 'query-string';
 import Tracker, {
   ContentImpression,
   ContentInteraction,
@@ -8,6 +7,7 @@ import Tracker, {
   TrackingEvent
 } from 'types/Tracker';
 import uniqId from './utils/uniqId';
+import { buildQueryString } from '../api/call';
 
 export interface RequiredTrackingParameters {
   idsite: number; // The ID of the website we're tracking a visit/action for.
@@ -143,7 +143,7 @@ export default class MatomoTracker implements Tracker {
 
   track = (parameters: OptionalTrackingParameters) => {
     return fetch(
-      `${this.trackerUrl}?${queryString.stringify({
+      `${this.trackerUrl}${buildQueryString({
         idsite: this.siteId,
         pv_id: this.pageViewId,
         apiv: 1,

--- a/src/webext/openOptionsTab.ts
+++ b/src/webext/openOptionsTab.ts
@@ -1,14 +1,19 @@
 import { CreateProperties } from './types';
+import { buildQueryString, GetParams } from '../api/call';
 
-export const getOptionsUrl = (pathname?: string) =>
-  `${process.env.PROFILES_ORIGIN}${pathname || '/sources'}`;
+export const getOptionsUrl = (pathname?: string, params: GetParams = {}) =>
+  `${process.env.PROFILES_ORIGIN || ''}${pathname ||
+    '/sources'}${buildQueryString(params)}`;
 
-const createOptionsTabsDescription = (pathname?: string): CreateProperties => ({
-  url: getOptionsUrl(pathname),
+const createOptionsTabsDescription = (
+  pathname?: string,
+  params?: GetParams
+): CreateProperties => ({
+  url: getOptionsUrl(pathname, params),
   active: true
 });
 
-const openOptions = (pathname?: string) =>
-  browser.tabs.create(createOptionsTabsDescription(pathname));
+const openOptions = (pathname?: string, params?: GetParams) =>
+  browser.tabs.create(createOptionsTabsDescription(pathname, params));
 
 export default openOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11075,7 +11075,7 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.8.2, query-string@^6.9.0:
+query-string@^6.8.2:
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.11.1.tgz#ab021f275d463ce1b61e88f0ce6988b3e8fe7c2c"
   dependencies:


### PR DESCRIPTION
I removed duplicated code for building a query string (for the ramda part I'm open to suggestion.
But I could as well keep the library instead of the custom function since it was there anyway and migth handl edge cases?
Or there's also the native URL and params browser API...