### PR TITLE
fix(contribution): track sendInBlue errors in Sentry

### DIFF
--- a/src/app/sagas/effects/callAndRetry.ts
+++ b/src/app/sagas/effects/callAndRetry.ts
@@ -11,6 +11,7 @@ type Options = {
   maximumAttempts: number;
   maximumRetryDelayInMinutes: number;
   onError?: OnErrorCallback;
+  onFinalError?: OnErrorCallback;
 };
 
 const defaultOptions: Options = {
@@ -49,6 +50,11 @@ export const createCallAndRetry = (options: Partial<Options>) =>
             attemptNumber + 1,
             ...args
           );
+        } else {
+          if ('onFinalError' in o && o.onFinalError) {
+            yield call(o.onFinalError, e, attemptNumber);
+          }
+          throw e;
         }
       }
     }

--- a/src/app/sagas/error.ts
+++ b/src/app/sagas/error.ts
@@ -9,13 +9,14 @@ import { BaseAction, ErrorAction } from '../actions';
 import { Level } from '../utils/Logger';
 
 export function* handleErrorSaga({
+  type,
   payload: error,
   meta: { severity }
 }: ErrorAction): SagaIterator {
   if (severity >= Level.ERROR) {
     captureException(error);
   } else {
-    captureMessage(error.message, severityToSentry[severity]);
+    captureMessage(error?.message || type, severityToSentry[severity]);
   }
 }
 


### PR DESCRIPTION
Since we have a blind spot on production monitoring right now, I wanted to keep this PR simple, without questioning the whole error tracking/logging mechanism that we may have to reconsider in a second stage.