### PR TITLE
Feature/respect do not track preference

### DIFF
--- a/src/app/background/sagas/index.ts
+++ b/src/app/background/sagas/index.ts
@@ -22,9 +22,12 @@ import { fetchRestrictedContextsSaga } from './fetchRestrictedContexts.saga';
 import connectSaga from './connect.saga';
 import installationDetailsSaga from './installationDetails.saga';
 import { loginSaga } from './user.saga';
+import { doNotTrackSettingFromNavigatorIsActivated } from '../../../webext/checkDoNotTrack';
 
 const tracker =
-  process.env.TRACKING_SITE_ID && process.env.TRACKING_URL
+  process.env.TRACKING_SITE_ID &&
+  process.env.TRACKING_URL &&
+  doNotTrackSettingFromNavigatorIsActivated() === false
     ? new MatomoTracker(process.env.TRACKING_SITE_ID, process.env.TRACKING_URL)
     : undefined;
 

--- a/src/webext/checkDoNotTrack.ts
+++ b/src/webext/checkDoNotTrack.ts
@@ -1,0 +1,9 @@
+export function doNotTrackSettingFromNavigatorIsActivated(): boolean {
+  const doNotTrack = window.doNotTrack || navigator.doNotTrack;
+
+  if (doNotTrack === '1' || doNotTrack === 'yes') {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
I completely delete all the tracking requests link to `MatomoTracker`. So in production, if the user checks "Do not track" in the navigator settings, no tracking requests will be executed
