### PR TITLE
chore: Differentiate 4xx Http errors from an actual server error

### DIFF
--- a/src/libs/api/APIStatusCodeError.ts
+++ b/src/libs/api/APIStatusCodeError.ts
@@ -3,7 +3,7 @@ export class APIStatusCodeError extends Error {
   public readonly statusCode: number;
 
   constructor(response: Response) {
-    super('Bad response from server');
+    super(response.statusText || 'Bad response from server');
     this.name = 'APIStatusCodeError';
     this.response = response;
     this.statusCode = response.status;


### PR DESCRIPTION
I tried not to impact the current behavior but just to change the 4xx error behavior.

> see #360 for history