### PR TITLE
feat(profiles): change link: sources to eclaireurs

### DIFF
--- a/src/app/background/sagas/serviceMessage.saga.ts
+++ b/src/app/background/sagas/serviceMessage.saga.ts
@@ -9,7 +9,7 @@ import { getServiceMessageLastShowDate } from '../selectors/serviceMessage.selec
 import { LinkType } from 'app/lmem/ServiceMessage';
 import { isWithinLastHours } from 'app/utils/areWithinHours';
 import { Level } from '../../utils/Logger';
-import { SOURCES } from '../../profiles/routes';
+import { CONTRIBUTORS_PATH } from '../../profiles/routes';
 
 export const buildMessages = (messages: string[], nbNotices = 0): string[] => {
   const firstMessage =
@@ -33,7 +33,7 @@ export default function* serviceMessageSaga(tab: Tab, nbNotices = 0) {
             messages: buildMessages([], nbNotices),
             action: {
               label: 'Choisir mes sources',
-              url: SOURCES,
+              url: CONTRIBUTORS_PATH,
               type: LinkType.Options
             }
           },

--- a/src/app/background/sagas/serviceMessage.saga.ts
+++ b/src/app/background/sagas/serviceMessage.saga.ts
@@ -9,6 +9,7 @@ import { getServiceMessageLastShowDate } from '../selectors/serviceMessage.selec
 import { LinkType } from 'app/lmem/ServiceMessage';
 import { isWithinLastHours } from 'app/utils/areWithinHours';
 import { Level } from '../../utils/Logger';
+import { SOURCES } from '../../profiles/routes';
 
 export const buildMessages = (messages: string[], nbNotices = 0): string[] => {
   const firstMessage =
@@ -32,7 +33,7 @@ export default function* serviceMessageSaga(tab: Tab, nbNotices = 0) {
             messages: buildMessages([], nbNotices),
             action: {
               label: 'Choisir mes sources',
-              url: '/sources',
+              url: SOURCES,
               type: LinkType.Options
             }
           },

--- a/src/app/content/App/ServiceMessage/ServiceMessage.stories.tsx
+++ b/src/app/content/App/ServiceMessage/ServiceMessage.stories.tsx
@@ -5,6 +5,7 @@ import { action } from '@storybook/addon-actions';
 import Notification from 'components/organisms/Notification';
 import ServiceMessage from './ServiceMessage';
 import { LinkType } from 'app/lmem/ServiceMessage';
+import { SOURCES } from '../../../profiles/routes';
 
 storiesOf('Extension/ServiceMessage', module)
   .addDecorator(getStory => (
@@ -17,7 +18,7 @@ storiesOf('Extension/ServiceMessage', module)
       messages={["I'm a service message!"]}
       action={{
         label: "I'm an action",
-        url: '/sources',
+        url: SOURCES,
         type: LinkType.Options
       }}
       openOnboarding={() => action('openOnboarding')}

--- a/src/app/content/App/ServiceMessage/ServiceMessage.stories.tsx
+++ b/src/app/content/App/ServiceMessage/ServiceMessage.stories.tsx
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions';
 import Notification from 'components/organisms/Notification';
 import ServiceMessage from './ServiceMessage';
 import { LinkType } from 'app/lmem/ServiceMessage';
-import { SOURCES } from '../../../profiles/routes';
+import { CONTRIBUTORS_PATH } from '../../../profiles/routes';
 
 storiesOf('Extension/ServiceMessage', module)
   .addDecorator(getStory => (
@@ -18,7 +18,7 @@ storiesOf('Extension/ServiceMessage', module)
       messages={["I'm a service message!"]}
       action={{
         label: "I'm an action",
-        url: SOURCES,
+        url: CONTRIBUTORS_PATH,
         type: LinkType.Options
       }}
       openOnboarding={() => action('openOnboarding')}

--- a/src/app/profiles/App/Pages/index.tsx
+++ b/src/app/profiles/App/Pages/index.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import Profiles from './Profiles';
 import Error from './Error';
 import Subscriptions from './Subscriptions';
+import { SOURCES } from '../../routes';
 
 const Pages = () => (
   <>
     <Switch>
-      <Redirect exact path="/" to="/sources" />
-      <Route path="/sources" component={Profiles} />
+      <Redirect exact path="/" to={SOURCES} />
+      <Route path={SOURCES} component={Profiles} />
       <Route path="/mes-abonnements" component={Subscriptions} />
       <Route component={Error} />
     </Switch>

--- a/src/app/profiles/App/Pages/index.tsx
+++ b/src/app/profiles/App/Pages/index.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import Profiles from './Profiles';
 import Error from './Error';
 import Subscriptions from './Subscriptions';
-import { SOURCES } from '../../routes';
+import { CONTRIBUTORS_PATH } from '../../routes';
 
 const Pages = () => (
   <>
     <Switch>
-      <Redirect exact path="/" to={SOURCES} />
-      <Route path={SOURCES} component={Profiles} />
+      <Redirect exact path="/" to={CONTRIBUTORS_PATH} />
+      <Route path={CONTRIBUTORS_PATH} component={Profiles} />
       <Route path="/mes-abonnements" component={Subscriptions} />
       <Route component={Error} />
     </Switch>

--- a/src/app/profiles/App/ProfileTabs.tsx
+++ b/src/app/profiles/App/ProfileTabs.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Tabs from 'components/molecules/Tabs';
 import Tab from 'components/atoms/Tab/Tab';
 import { Sidebar, TwoColumns } from 'components/atoms';
+import { SOURCES } from '../routes';
 
 interface ProfileTabsProps {
   connected?: boolean;
@@ -25,7 +26,7 @@ const ProfileTabs = ({ connected }: ProfileTabsProps) => {
   if (connected) {
     return (
       <ProfileTabsContainer>
-        <Tab to={'/sources'}>{t('profiles:menu.sources')}</Tab>
+        <Tab to={SOURCES}>{t('profiles:menu.sources')}</Tab>
         <Tab to={'/mes-abonnements'}>{t('profiles:menu.subscriptions')}</Tab>
       </ProfileTabsContainer>
     );

--- a/src/app/profiles/App/ProfileTabs.tsx
+++ b/src/app/profiles/App/ProfileTabs.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import Tabs from 'components/molecules/Tabs';
 import Tab from 'components/atoms/Tab/Tab';
 import { Sidebar, TwoColumns } from 'components/atoms';
-import { SOURCES } from '../routes';
+import { CONTRIBUTORS_PATH } from '../routes';
 
 interface ProfileTabsProps {
   connected?: boolean;
@@ -26,7 +26,7 @@ const ProfileTabs = ({ connected }: ProfileTabsProps) => {
   if (connected) {
     return (
       <ProfileTabsContainer>
-        <Tab to={SOURCES}>{t('profiles:menu.sources')}</Tab>
+        <Tab to={CONTRIBUTORS_PATH}>{t('profiles:menu.sources')}</Tab>
         <Tab to={'/mes-abonnements'}>{t('profiles:menu.subscriptions')}</Tab>
       </ProfileTabsContainer>
     );

--- a/src/app/profiles/App/SimilarProfiles/SimilarProfiles.tsx
+++ b/src/app/profiles/App/SimilarProfiles/SimilarProfiles.tsx
@@ -17,6 +17,7 @@ import ContributorCompact from 'components/organisms/Contributor/ContributorComp
 import ContributorNameLink from 'components/organisms/Contributor/ContributorNameLink';
 import pathToContributor from '../pathToContributor';
 import withConnect from './withConnect';
+import { SOURCES } from '../../routes';
 
 interface SimilarProfilesProps {
   loading?: boolean;
@@ -87,7 +88,7 @@ const SimilarProfiles = ({
           ))}
       </SidebarBox>
       <CenterContainer>
-        <Link to="/sources">{t('profiles:action.see_all')}</Link>
+        <Link to={SOURCES}>{t('profiles:action.see_all')}</Link>
       </CenterContainer>
     </>
   );

--- a/src/app/profiles/App/SimilarProfiles/SimilarProfiles.tsx
+++ b/src/app/profiles/App/SimilarProfiles/SimilarProfiles.tsx
@@ -17,7 +17,7 @@ import ContributorCompact from 'components/organisms/Contributor/ContributorComp
 import ContributorNameLink from 'components/organisms/Contributor/ContributorNameLink';
 import pathToContributor from '../pathToContributor';
 import withConnect from './withConnect';
-import { SOURCES } from '../../routes';
+import { CONTRIBUTORS_PATH } from '../../routes';
 
 interface SimilarProfilesProps {
   loading?: boolean;
@@ -88,7 +88,7 @@ const SimilarProfiles = ({
           ))}
       </SidebarBox>
       <CenterContainer>
-        <Link to={SOURCES}>{t('profiles:action.see_all')}</Link>
+        <Link to={CONTRIBUTORS_PATH}>{t('profiles:action.see_all')}</Link>
       </CenterContainer>
     </>
   );

--- a/src/app/profiles/App/pathToContributor.ts
+++ b/src/app/profiles/App/pathToContributor.ts
@@ -1,7 +1,8 @@
 import slugify from 'slugify';
 import { Contributor } from 'app/lmem/contributor';
+import { SOURCES } from '../routes';
 
 const pathToContributor = (contributor: Contributor) =>
-  `/sources/${contributor.id}/${slugify(contributor.name)}`;
+  `${SOURCES}/${contributor.id}/${slugify(contributor.name)}`;
 
 export default pathToContributor;

--- a/src/app/profiles/App/pathToContributor.ts
+++ b/src/app/profiles/App/pathToContributor.ts
@@ -1,8 +1,8 @@
 import slugify from 'slugify';
 import { Contributor } from 'app/lmem/contributor';
-import { SOURCES } from '../routes';
+import { CONTRIBUTORS_PATH } from '../routes';
 
 const pathToContributor = (contributor: Contributor) =>
-  `${SOURCES}/${contributor.id}/${slugify(contributor.name)}`;
+  `${CONTRIBUTORS_PATH}/${contributor.id}/${slugify(contributor.name)}`;
 
 export default pathToContributor;

--- a/src/app/profiles/routes/index.ts
+++ b/src/app/profiles/routes/index.ts
@@ -1,3 +1,3 @@
 type ProfilePath = '/eclaireurs' | '/mes-abonnements';
 
-export const SOURCES: ProfilePath = '/eclaireurs';
+export const CONTRIBUTORS_PATH: ProfilePath = '/eclaireurs';

--- a/src/app/profiles/routes/index.ts
+++ b/src/app/profiles/routes/index.ts
@@ -1,0 +1,3 @@
+type ProfilePath = '/eclaireurs' | '/mes-abonnements';
+
+export const SOURCES: ProfilePath = '/eclaireurs';

--- a/src/app/profiles/store/sagas/locationChange.saga.ts
+++ b/src/app/profiles/store/sagas/locationChange.saga.ts
@@ -4,7 +4,7 @@ import { refreshContributors } from 'app/actions';
 import { fetchContributorNotices } from '../actions/notices';
 import { fetchContributorRequest } from 'app/actions/contributor';
 import takeLatestLocationChange from 'app/store/sagas/effects/takeLatestLocationChange';
-import { SOURCES } from '../../routes';
+import { CONTRIBUTORS_PATH } from '../../routes';
 
 function* contributorsLocationSaga() {
   yield put(refreshContributors());
@@ -17,10 +17,10 @@ function* contributorLocationSaga(match: Match<{ id: string }>) {
 }
 
 export default function* locationChangeSaga() {
-  yield takeLatestLocationChange(SOURCES, contributorsLocationSaga);
+  yield takeLatestLocationChange(CONTRIBUTORS_PATH, contributorsLocationSaga);
   yield takeLatestLocationChange('/mes-abonnements', contributorsLocationSaga);
   yield takeLatestLocationChange<{ id: string }>(
-    SOURCES + '/:id/:slug',
+    CONTRIBUTORS_PATH + '/:id/:slug',
     contributorLocationSaga
   );
 }

--- a/src/app/profiles/store/sagas/locationChange.saga.ts
+++ b/src/app/profiles/store/sagas/locationChange.saga.ts
@@ -4,6 +4,7 @@ import { refreshContributors } from 'app/actions';
 import { fetchContributorNotices } from '../actions/notices';
 import { fetchContributorRequest } from 'app/actions/contributor';
 import takeLatestLocationChange from 'app/store/sagas/effects/takeLatestLocationChange';
+import { SOURCES } from '../../routes';
 
 function* contributorsLocationSaga() {
   yield put(refreshContributors());
@@ -16,10 +17,10 @@ function* contributorLocationSaga(match: Match<{ id: string }>) {
 }
 
 export default function* locationChangeSaga() {
-  yield takeLatestLocationChange('/sources', contributorsLocationSaga);
+  yield takeLatestLocationChange(SOURCES, contributorsLocationSaga);
   yield takeLatestLocationChange('/mes-abonnements', contributorsLocationSaga);
   yield takeLatestLocationChange<{ id: string }>(
-    '/sources/:id/:slug',
+    SOURCES + '/:id/:slug',
     contributorLocationSaga
   );
 }

--- a/src/webext/openOptionsTab.ts
+++ b/src/webext/openOptionsTab.ts
@@ -1,9 +1,10 @@
 import { CreateProperties } from './types';
 import { buildQueryString, GetParams } from '../api/call';
+import { CONTRIBUTORS_PATH } from '../app/profiles/routes';
 
 export const getOptionsUrl = (pathname?: string, params: GetParams = {}) =>
   `${process.env.PROFILES_ORIGIN || ''}${pathname ||
-    '/sources'}${buildQueryString(params)}`;
+    CONTRIBUTORS_PATH}${buildQueryString(params)}`;
 
 const createOptionsTabsDescription = (
   pathname?: string,


### PR DESCRIPTION
closes #827 
I added a new folder /routes in root of app/profiles with new file which export const SOURCES =/eclaireurs wherever it is needed