### PR TITLE
fix(NoticesList): way to display more than 2 notices

### DIFF
--- a/src/app/content/App/Notice/List/List.stories.tsx
+++ b/src/app/content/App/Notice/List/List.stories.tsx
@@ -12,6 +12,7 @@ import { ListScreen } from '.';
 
 const firstMessage = defaultMessage;
 const secondMessage = `De nombreux clients mécontents de Pixmania et ses vendeurs s'expriment sur les réseaux sociaux depuis 2016. Les plaintes continuent en 2017, 2018 et encore en 2019 si l'on se réfère au forum Que Choisir.`;
+const thirdMessage = 'yolo';
 const commonProps = {
   close: action('close'),
   dismiss: action('dismiss'),
@@ -51,6 +52,25 @@ storiesOf('Extension/Notice/List', module)
         generateStatefulNotice({
           dismissed: boolean('dismissed(2)', false, 'second'),
           message: `<p>${text('message(2)', secondMessage, 'second')}</p>`
+        })
+      ]}
+    />
+  ))
+  .add('3 notices', () => (
+    <ListScreen
+      {...commonProps}
+      notices={[
+        generateStatefulNotice({
+          dismissed: boolean('dismissed(1)', false, 'first'),
+          message: `<p>${text('message(1)', firstMessage, 'first')}</p>`
+        }),
+        generateStatefulNotice({
+          dismissed: boolean('dismissed(2)', false, 'second'),
+          message: `<p>${text('message(2)', secondMessage, 'second')}</p>`
+        }),
+        generateStatefulNotice({
+          dismissed: boolean('dismissed(3)', false, 'third'),
+          message: `<p>${text('message(3)', thirdMessage, 'third')}</p>`
         })
       ]}
     />

--- a/src/app/content/App/Notice/List/ListContainer.ts
+++ b/src/app/content/App/Notice/List/ListContainer.ts
@@ -2,8 +2,10 @@ import styled from 'styled-components';
 
 export default styled.div`
   width: 100%;
+  max-height: 242px;
+  overflow-y: auto;
 
   &:not(:empty) {
-    padding-top: 18px;
+    margin-top: 18px;
   }
 `;

--- a/src/app/content/App/Notice/List/ListContainer.ts
+++ b/src/app/content/App/Notice/List/ListContainer.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export default styled.div`
   width: 100%;
-  max-height: 242px;
+  max-height: 265px;
   overflow-y: auto;
 
   &:not(:empty) {

--- a/src/app/content/App/Notice/List/index.tsx
+++ b/src/app/content/App/Notice/List/index.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
+import styled from 'styled-components';
 import { useTransition } from 'react-spring';
 
-import { AddNoticeContainer } from 'components/atoms';
+import { StatefulNoticeWithContributor } from 'app/lmem/notice';
+import { Contributor } from 'app/lmem/contributor';
+
+import { AddNoticeContainer, Paragraph } from 'components/atoms';
 import AddNoticeButton from 'components/atoms/Button/AddNoticeButton';
 import NoticeItem, {
   NoticeTransitionProps,
   transitionKeys
 } from 'components/organisms/Notice/Notice';
 import ListContainer from './ListContainer';
-import { StatefulNoticeWithContributor } from 'app/lmem/notice';
-import { Contributor } from 'app/lmem/contributor';
 import withConnect from './withConnect';
+
+const BullesNumber = styled(Paragraph)`
+  margin-top: 10px;
+  text-align: center;
+`;
 
 export interface Props {
   notices: StatefulNoticeWithContributor[];
@@ -28,7 +35,7 @@ export const ListScreen = ({
   onContributorClick
 }: Props) => {
   const transitions = useTransition(
-    notices.slice(0, 2),
+    notices.slice(0, 3),
     notice => notice.id,
     // eslint-disable-next-line
     // @ts-ignore
@@ -52,6 +59,9 @@ export const ListScreen = ({
           )
         )}
       </ListContainer>
+      <BullesNumber>
+        Il y a <strong>3</strong> Bulles pour cette page
+      </BullesNumber>
       <AddNoticeContainer>
         <AddNoticeButton />
       </AddNoticeContainer>

--- a/src/app/content/App/Notice/List/index.tsx
+++ b/src/app/content/App/Notice/List/index.tsx
@@ -53,6 +53,7 @@ export const ListScreen = ({
           )
         )}
       </ListContainer>
+
       <AddNoticeContainer>
         <AddNoticeButton />
       </AddNoticeContainer>

--- a/src/app/content/App/Notice/List/index.tsx
+++ b/src/app/content/App/Notice/List/index.tsx
@@ -54,7 +54,7 @@ export const ListScreen = ({
         )}
       </ListContainer>
 
-      <AddNoticeContainer>
+      <AddNoticeContainer shadow={countNotices > 2}>
         <AddNoticeButton />
       </AddNoticeContainer>
     </>

--- a/src/app/content/App/Notice/List/index.tsx
+++ b/src/app/content/App/Notice/List/index.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
-import styled from 'styled-components';
 import { useTransition } from 'react-spring';
-
 import { StatefulNoticeWithContributor } from 'app/lmem/notice';
 import { Contributor } from 'app/lmem/contributor';
-
-import { AddNoticeContainer, Paragraph } from 'components/atoms';
+import { AddNoticeContainer } from 'components/atoms';
 import AddNoticeButton from 'components/atoms/Button/AddNoticeButton';
 import NoticeItem, {
   NoticeTransitionProps,
@@ -13,11 +10,6 @@ import NoticeItem, {
 } from 'components/organisms/Notice/Notice';
 import ListContainer from './ListContainer';
 import withConnect from './withConnect';
-
-const BullesNumber = styled(Paragraph)`
-  margin-top: 10px;
-  text-align: center;
-`;
 
 export interface Props {
   notices: StatefulNoticeWithContributor[];
@@ -34,8 +26,10 @@ export const ListScreen = ({
   undismiss,
   onContributorClick
 }: Props) => {
+  const countNotices = (notices && notices.length) || 0;
+
   const transitions = useTransition(
-    notices.slice(0, 3),
+    notices.slice(0, countNotices),
     notice => notice.id,
     // eslint-disable-next-line
     // @ts-ignore
@@ -59,9 +53,6 @@ export const ListScreen = ({
           )
         )}
       </ListContainer>
-      <BullesNumber>
-        Il y a <strong>3</strong> Bulles pour cette page
-      </BullesNumber>
       <AddNoticeContainer>
         <AddNoticeButton />
       </AddNoticeContainer>

--- a/src/components/atoms/AddNoticeContainer.ts
+++ b/src/components/atoms/AddNoticeContainer.ts
@@ -1,11 +1,15 @@
 import styled from 'styled-components';
 import CenterContainer from './CenterContainer';
 
-export default styled(CenterContainer)`
+interface AddNoticeContainerProps {
+  shadow?: boolean;
+}
+
+export default styled(CenterContainer)<AddNoticeContainerProps>`
   width: 100%;
   position: absolute;
   // bottom: 60px; // In case of ServiceMessageLine
-  bottom: 16px;
-  box-shadow: 0 -4px 4px rgba(0, 0, 0, 0.4);
-  padding-top: 18px;
+  bottom: 14px;
+  box-shadow: ${props => (props.shadow ? '0 -2px 2px rgba(0, 0, 0, 0.4)' : '')};
+  padding-top: 14px;
 `;

--- a/src/components/atoms/AddNoticeContainer.ts
+++ b/src/components/atoms/AddNoticeContainer.ts
@@ -6,4 +6,6 @@ export default styled(CenterContainer)`
   position: absolute;
   // bottom: 60px; // In case of ServiceMessageLine
   bottom: 16px;
+  box-shadow: 0 -4px 4px rgba(0, 0, 0, 0.4);
+  padding-top: 18px;
 `;

--- a/src/components/atoms/AddNoticeContainer.ts
+++ b/src/components/atoms/AddNoticeContainer.ts
@@ -5,5 +5,5 @@ export default styled(CenterContainer)`
   width: 100%;
   position: absolute;
   // bottom: 60px; // In case of ServiceMessageLine
-  bottom: 25px;
+  bottom: 16px;
 `;

--- a/src/components/atoms/Button/AddNoticeButton/AddNoticeButton.tsx
+++ b/src/components/atoms/Button/AddNoticeButton/AddNoticeButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Link } from 'components/atoms';
 
@@ -22,4 +23,7 @@ const LinkNoNotice = styled(Link)`
   }
 `;
 
-export default () => <LinkNoNotice to="/contribute">Poster</LinkNoNotice>;
+export default () => {
+  const { t } = useTranslation();
+  return <LinkNoNotice to="/contribute">{t('action.post')}</LinkNoNotice>;
+};

--- a/src/components/atoms/Button/AddNoticeButton/AddNoticeButton.tsx
+++ b/src/components/atoms/Button/AddNoticeButton/AddNoticeButton.tsx
@@ -7,6 +7,7 @@ const LinkNoNotice = styled(Link)`
   padding: 3px 12px;
   color: ${props => props.theme.Button.default};
   font-weight: 900;
+  font-size: 16px;
   line-height: 1;
   text-decoration: none;
   text-transform: none;

--- a/src/components/organisms/Notice/Container.ts
+++ b/src/components/organisms/Notice/Container.ts
@@ -18,6 +18,9 @@ export default styled(animated.article)<Props>`
   align-items: center;
   justify-content: flex-end;
   font-size: ${props => (props.details ? '15px' : '16px')};
-  margin-bottom: 18px;
   backface-visibility: hidden;
+
+  &:not(:last-of-type) {
+    margin-bottom: 18px;
+  }
 `;

--- a/src/components/organisms/Notice/Content.ts
+++ b/src/components/organisms/Notice/Content.ts
@@ -14,7 +14,6 @@ interface ContentProps {
 export default styled.div<ContentProps>`
   box-sizing: border-box;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   width: 338px;
   min-height: 85px;


### PR DESCRIPTION
A way to fix #850

@MaartenLMEM / @christpet visually it would be something like 
![image](https://user-images.githubusercontent.com/657454/112502845-b6fd7800-8d8a-11eb-96df-b96fb5ea50a6.png)

@gregoirelacoste could you find a way to hide the message if there's less than 2 notices?
