### PR TITLE
feat(onBoardingEvolution): detect isChrome for step2, change wording

### DIFF
--- a/src/app/profiles/App/OnBoarding/Steps/Step1.tsx
+++ b/src/app/profiles/App/OnBoarding/Steps/Step1.tsx
@@ -3,6 +3,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import styled, { keyframes } from 'styled-components';
 import { Title1 } from 'components/atoms/Title1';
 import { StepProps } from './index';
+import isChrome from '../../../../utils/isChrome';
 
 const titleAnim = keyframes`
   from {
@@ -53,11 +54,12 @@ export default ({ next }: StepProps) => {
     <>
       <Step1Title>
         <AnimatedText onAnimationEnd={onAnimationEnd}>
-          <Trans t={t} i18nKey="view.onBoarding.step1">
+          <Trans t={t} i18nKey="view.onBoarding.step1.loading">
             L&apos;installation a réussi !<br /> Chargement de votre
             expérience...
-            <br /> Épinglez DisMoi
           </Trans>
+          <br />
+          {isChrome && t('view.onBoarding.step1.pin')}
         </AnimatedText>
       </Step1Title>
     </>

--- a/src/app/profiles/App/OnBoarding/Steps/Step2.tsx
+++ b/src/app/profiles/App/OnBoarding/Steps/Step2.tsx
@@ -12,6 +12,8 @@ import Content from '../components/Content';
 import { StepProps } from './index';
 
 const MarginTitle = styled(Title1)`
+  margin-top: 0;
+  margin-bottom: 60px;
   margin-left: 200px;
 `;
 

--- a/src/app/profiles/App/OnBoarding/Steps/Step3.tsx
+++ b/src/app/profiles/App/OnBoarding/Steps/Step3.tsx
@@ -12,6 +12,8 @@ import { StepProps } from './index';
 import isChrome from 'app/utils/isChrome';
 
 const MarginTitle = styled(Title1)`
+  margin-top: 0;
+  margin-bottom: 60px;
   margin-left: 130px;
 `;
 

--- a/src/app/profiles/App/OnBoarding/Steps/Step3.tsx
+++ b/src/app/profiles/App/OnBoarding/Steps/Step3.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { useTranslation, Trans } from 'react-i18next';
 import { Bullito, Reload } from 'components/atoms/icons';
 import { Title1 } from 'components/atoms/Title1';
@@ -9,6 +9,7 @@ import Line from '../components/Line';
 import OnboardingButton from '../components/Buttons';
 import OnboardingTitle from '../components/Title';
 import { StepProps } from './index';
+import isChrome from 'app/utils/isChrome';
 
 const MarginTitle = styled(Title1)`
   margin-left: 130px;
@@ -21,11 +22,22 @@ const OnboardingText = styled(Text)`
     margin-top: 60px;
   }
 `;
+const contentAnim = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+const ContentWithEffect = styled(Content)`
+  animation: ${contentAnim} 500ms linear forwards;
+`;
 
 export default ({ prev, close }: StepProps) => {
   const { t } = useTranslation('profiles');
   return (
-    <Content>
+    <ContentWithEffect>
       <MarginTitle>{t('view.onBoarding.step3.title')}</MarginTitle>
 
       <Line>
@@ -47,18 +59,20 @@ export default ({ prev, close }: StepProps) => {
         </OnboardingText>
       </Trans>
       <Line>
-        <div>
-          <OnboardingButton color="inactive" onClick={prev}>
-            <Reload />
-            {t('view.onBoarding.step3.back_button')}
-          </OnboardingButton>
-        </div>
+        {isChrome && (
+          <div>
+            <OnboardingButton color="inactive" onClick={prev}>
+              <Reload />
+              {t('view.onBoarding.step3.back_button')}
+            </OnboardingButton>
+          </div>
+        )}
         <div>
           <OnboardingButton onClick={close}>
             {t('action.finish')}
           </OnboardingButton>
         </div>
       </Line>
-    </Content>
+    </ContentWithEffect>
   );
 };

--- a/src/app/profiles/App/OnBoarding/components/Buttons.tsx
+++ b/src/app/profiles/App/OnBoarding/components/Buttons.tsx
@@ -11,8 +11,8 @@ const getBackgroundColor = (color: Color) => {
 const OnboardingButton = styled(BackgroundButton)`
   display: flex;
   align-items: center;
-  padding: 15px 34px;
-  font-size: 30px;
+  padding: 10px 20px;
+  font-size: 22px;
   line-height: 1.2;
   font-weight: 600;
   background-color: ${({ color }) => getBackgroundColor(color)};
@@ -25,9 +25,9 @@ const OnboardingButton = styled(BackgroundButton)`
   }
 
   svg {
-    width: 32px;
+    width: 20px;
     height: auto;
-    margin-right: 16px;
+    margin-right: 8px;
   }
 `;
 

--- a/src/app/profiles/App/OnBoarding/components/Line.tsx
+++ b/src/app/profiles/App/OnBoarding/components/Line.tsx
@@ -23,13 +23,13 @@ const Line = styled.div`
   }
 
   p {
-    font-size: 28px;
+    font-size: 22px;
     text-align: center;
   }
 
   button {
     justify-content: center;
-    min-width: 360px;
+    min-width: 216px;
   }
 `;
 

--- a/src/app/profiles/App/OnBoarding/components/Title.tsx
+++ b/src/app/profiles/App/OnBoarding/components/Title.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Title } from 'components/atoms';
 
 const OnboardingTitle = styled(Title)`
-  max-width: 330px;
+  max-width: 360px;
   margin-left: 62px;
   font-size: 30px;
   color: ${props => props.theme.primaryColor};

--- a/src/app/profiles/App/OnBoarding/components/Top.tsx
+++ b/src/app/profiles/App/OnBoarding/components/Top.tsx
@@ -24,10 +24,11 @@ export default styled.div`
     display: flex;
     flex-direction: column;
     width: 610px;
-    margin-left: 64px;
+    margin-left: 80px;
   }
 
   > svg {
+    width: 200px;
     margin-top: 80px;
   }
 `;

--- a/src/app/profiles/App/OnBoarding/index.tsx
+++ b/src/app/profiles/App/OnBoarding/index.tsx
@@ -8,6 +8,7 @@ import Evolution from './components/Evolution';
 import Modal from './components/Modal';
 import { Step1, Step2, Step3 } from './Steps';
 import isRedirectedFromExtensionInstall from 'app/utils/isRedirectedFromExtensionInstall';
+import isChrome from 'app/utils/isChrome';
 
 export type CloseFunction = () => void;
 
@@ -27,6 +28,7 @@ const OnBoarding = () => {
     <Step2 key={1} prev={prev} next={next} />,
     <Step3 key={2} prev={prev} close={close} />
   ];
+  if (!isChrome) steps.splice(1, 1);
 
   return (
     <Modal open={open} close={close}>

--- a/src/app/utils/isChrome.ts
+++ b/src/app/utils/isChrome.ts
@@ -1,0 +1,1 @@
+export default Object.entries(window.browser).length > 0;

--- a/src/i18n/resources/en/profiles.json
+++ b/src/i18n/resources/en/profiles.json
@@ -82,7 +82,10 @@
       "description_dismoi": "DisMoi lets internet users, media and experts share helpful information directly on the webpages you visit."
     },
     "onBoarding": {
-      "step1": "DisMoi is installed!<br/>  Your experience is loading...<br/>  Pin DisMoi in your Browser",
+      "step1": {
+        "loading": "DisMoi is up to date!<br/>  Your experience is loading...",
+        "pin": "Pin DisMoi in your Browser"
+      },
       "step2": {
         "title": "Pin DisMoi",
         "question": "Did you pin the DisMoi extension in your browser?",

--- a/src/i18n/resources/fr/profiles.json
+++ b/src/i18n/resources/fr/profiles.json
@@ -82,7 +82,10 @@
       "description_dismoi": "DisMoi permet aux internautes, médias et experts de vous informer directement sur les pages web que vous visitez."
     },
     "onBoarding": {
-      "step1": "L'installation a réussi !<br/>  Chargement de votre expérience...<br/>  Épinglez DisMoi",
+      "step1": {
+        "loading": "L'extension est à jour !<br/>  Chargement de votre expérience...",
+        "pin": "Épinglez DisMoi"
+      },
       "step2": {
         "title": "Épinglez DisMoi",
         "question": "Êtes-vous arrivé à épingler l'extension DisMoi ?",


### PR DESCRIPTION
closes #902 

last changes:
- new wording: Instead of "l'installation a réussi", it could be "L'extension est à jour"
- separate experience for Firefox and Chrome Users. On Firefox, only 2 steps, not the pinning part.

@newick @MaartenLMEM @coffeeandpixel 
![image](https://user-images.githubusercontent.com/60737012/114882735-8b5b3400-9e04-11eb-9c2f-7df3ec98cee7.png)
