### PR TITLE
perf: change matching contexts periodical refresh logic

### DIFF
--- a/src/app/background/sagas/refreshMatchingContexts.ts
+++ b/src/app/background/sagas/refreshMatchingContexts.ts
@@ -12,15 +12,33 @@ import { getSubscriptions } from 'app/background/selectors/subscriptions.selecto
 import fetchMatchingContexts from 'api/fetchMatchingContexts';
 import minutesToMilliseconds from 'app/utils/minutesToMilliseconds';
 
-export function* refreshMatchingContextsSaga() {
-  const callAndRetry = createCallAndRetry({
-    maximumRetryDelayInMinutes: 10,
-    onError: function*(error: Error) {
-      yield put(refreshMatchingContextsFailed(error));
-    }
-  });
+const refreshInterval = minutesToMilliseconds(
+  Number(process.env.REFRESH_MC_INTERVAL)
+);
 
+if (refreshInterval > 0) {
+  // eslint-disable-next-line no-console
+  console.info(
+    `Matching contexts will be refreshed every ${process.env.REFRESH_MC_INTERVAL} minutes.`
+  );
+} else {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'Matching contexts auto-refresh disabled:',
+    'assuming "process.env.REFRESH_MC_INTERVAL" is deliberately not defined.'
+  );
+}
+
+const callAndRetry = createCallAndRetry({
+  maximumRetryDelayInMinutes: 10,
+  onError: function*(error: Error) {
+    yield put(refreshMatchingContextsFailed(error));
+  }
+});
+
+export function* refreshMatchingContextsSaga() {
   const subscriptions = yield select(getSubscriptions);
+
   const matchingContexts = yield callAndRetry(
     fetchMatchingContexts,
     subscriptions
@@ -29,31 +47,10 @@ export function* refreshMatchingContextsSaga() {
   if (matchingContexts) {
     yield put(receivedMatchingContexts(matchingContexts));
   }
-}
-
-export function* refreshMatchingContextsPeriodicallySaga() {
-  yield put(refreshMatchingContexts());
-
-  const refreshInterval = minutesToMilliseconds(
-    Number(process.env.REFRESH_MC_INTERVAL)
-  );
 
   if (refreshInterval > 0) {
-    // eslint-disable-next-line no-console
-    console.info(
-      `Matching contexts will be refreshed every ${process.env.REFRESH_MC_INTERVAL} minutes.`
-    );
-
-    while (true) {
-      yield delay(refreshInterval);
-      yield put(refreshMatchingContexts());
-    }
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Matching contexts auto-refresh disabled:',
-      'assuming "process.env.REFRESH_MC_INTERVAL" is deliberately not defined.'
-    );
+    yield delay(refreshInterval);
+    yield put(refreshMatchingContexts());
   }
 }
 
@@ -62,5 +59,4 @@ export default function* refreshMatchingContextsRootSaga() {
     [SUBSCRIBE, UNSUBSCRIBE, REFRESH_MATCHING_CONTEXTS],
     refreshMatchingContextsSaga
   );
-  yield fork(refreshMatchingContextsPeriodicallySaga);
 }


### PR DESCRIPTION
This is in order to avoid parallel fetching attemps in case previous one still hasn’t succeeded. With this, we only request a new refresh once previous one has succeeded.

Relates to #861 