### PR TITLE
perf: change contributors periodical refresh logic

### DIFF
--- a/src/app/background/sagas/refreshContributors.ts
+++ b/src/app/background/sagas/refreshContributors.ts
@@ -3,27 +3,29 @@ import { REFRESH_CONTRIBUTORS, refreshContributors } from 'app/actions';
 import minutesToMilliseconds from 'app/utils/minutesToMilliseconds';
 import refreshContributorsSaga from 'app/store/sagas/refreshContributors.saga';
 
-export function* refreshContributorsPeriodicallySaga() {
-  const refreshInterval = minutesToMilliseconds(
-    Number(process.env.REFRESH_CONTRIBUTORS_INTERVAL)
+const refreshInterval = minutesToMilliseconds(
+  Number(process.env.REFRESH_CONTRIBUTORS_INTERVAL)
+);
+
+if (refreshInterval > 0) {
+  // eslint-disable-next-line no-console
+  console.info(
+    `Contributors will be refreshed every ${process.env.REFRESH_CONTRIBUTORS_INTERVAL} minutes.`
   );
+} else {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'Contributors auto-refresh disabled:',
+    'assuming "process.env.REFRESH_CONTRIBUTORS_INTERVAL" is deliberately not defined.'
+  );
+}
+
+export function* refreshContributorsPeriodicallySaga() {
+  yield refreshContributorsSaga();
 
   if (refreshInterval > 0) {
-    // eslint-disable-next-line no-console
-    console.info(
-      `Contributors will be refreshed every ${process.env.REFRESH_CONTRIBUTORS_INTERVAL} minutes.`
-    );
-
-    while (true) {
-      yield put(refreshContributors());
-      yield delay(refreshInterval);
-    }
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Contributors auto-refresh disabled:',
-      'assuming "process.env.REFRESH_CONTRIBUTORS_INTERVAL" is deliberately not defined.'
-    );
+    yield delay(refreshInterval);
+    yield put(refreshContributors());
   }
 }
 


### PR DESCRIPTION
This is in order to avoid parallel fetching attemps in case previous one still hasn’t succeeded. With this, we only request a new refresh once previous one has succeeded.

Same spirit as #917 but for contributors

Related to #861 