### PR TITLE
Badge on network error

### DIFF
--- a/src/app/actions/index.ts
+++ b/src/app/actions/index.ts
@@ -25,6 +25,7 @@ import {
 } from './ui';
 import {
   FeedbackOnNoticeAction,
+  FetchNoticeFailureAction,
   MarkNoticeReadAction,
   NoNoticesDisplayedAction,
   NoticeDisplayedAction,
@@ -205,4 +206,5 @@ export type AppAction =
   | LocationChangedAction
   | OutboundLinkClickedAction
   | LoginAction
+  | FetchNoticeFailureAction
   | (LocationChangeAction & { meta?: ActionMeta });

--- a/src/app/background/reducers/index.ts
+++ b/src/app/background/reducers/index.ts
@@ -9,6 +9,7 @@ import tabs, { TabsState } from './tabs.reducer';
 import subscriptions, { SubscriptionsState } from './subscriptions.reducer';
 import user, { UserState } from './user';
 import serviceMessage, { ServiceMessageState } from './serviceMessage.reducer';
+import status, { StatusState } from './status';
 
 export interface StateWithSubscriptions {
   subscriptions: SubscriptionsState;
@@ -21,6 +22,7 @@ export interface PersistedBackgroundState
   installationDetails: InstallationDetailsState;
   serviceMessage: ServiceMessageState;
   user: UserState;
+  status: StatusState;
 }
 
 export interface StateWithResources {
@@ -43,5 +45,6 @@ export default combineReducers({
   tabs,
   subscriptions,
   user,
-  serviceMessage
+  serviceMessage,
+  status
 });

--- a/src/app/background/reducers/status.ts
+++ b/src/app/background/reducers/status.ts
@@ -1,0 +1,38 @@
+import {
+  AppAction,
+  FETCH_NOTICES_FAILURE,
+  NOTICES_FETCHED,
+  REFRESH_CONTRIBUTORS_FAILED,
+  REFRESH_MATCHING_CONTEXTS_FAILED,
+  UPDATE_CONTRIBUTORS,
+  UPDATE_MATCHING_CONTEXTS
+} from 'app/actions';
+
+export interface StatusState {
+  backendLinkFailed: boolean;
+}
+
+const initialState: StatusState = { backendLinkFailed: false };
+
+export default (
+  state: StatusState = initialState,
+  action: AppAction
+): StatusState => {
+  switch (action.type) {
+    case REFRESH_MATCHING_CONTEXTS_FAILED:
+    case REFRESH_CONTRIBUTORS_FAILED:
+    case FETCH_NOTICES_FAILURE:
+      return {
+        ...state,
+        backendLinkFailed: true
+      };
+
+    case UPDATE_MATCHING_CONTEXTS:
+    case UPDATE_CONTRIBUTORS:
+    case NOTICES_FETCHED:
+      return { ...state, backendLinkFailed: false };
+
+    default:
+      return state;
+  }
+};

--- a/src/app/background/selectors/status.selector.ts
+++ b/src/app/background/selectors/status.selector.ts
@@ -1,0 +1,12 @@
+import { StatusState } from '../reducers/status';
+import { createSelector } from 'reselect';
+
+export const selectBackendLinkFailed = ({ status }: { status: StatusState }) =>
+  status.backendLinkFailed;
+
+export type ConnectivityStatus = 'FAILED' | 'OK';
+
+export const selectStatus = createSelector(
+  [selectBackendLinkFailed],
+  backendLinkFailed => (backendLinkFailed ? 'FAILED' : 'OK')
+);

--- a/src/app/lmem/badge.ts
+++ b/src/app/lmem/badge.ts
@@ -5,12 +5,24 @@ export interface BadgeTheme {
   backgroundColor: {
     hasAllNoticesRead: string;
     hasUnreadNotices: string;
+    hasFailed: string;
   };
 }
 
 export const resetBadge = (tabId?: number) => {
   browser.browserAction.setBadgeText({ text: '', tabId });
-  browser.browserAction.setIcon({ path: greyIcons });
+  browser.browserAction.setIcon({ path: greyIcons, tabId });
+};
+
+export const failBadge = (badgeTheme: BadgeTheme, tabId?: number) => {
+  browser.browserAction.setBadgeText({ text: '🔴️', tabId });
+  browser.browserAction.setBadgeBackgroundColor({
+    color: badgeTheme.backgroundColor.hasFailed
+  });
+  browser.browserAction.setIcon({ path: greyIcons, tabId });
+  browser.browserAction.setTitle({
+    title: 'Problème de communication avec le backend'
+  });
 };
 
 /**

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -108,7 +108,8 @@ export const theme: Theme = {
   badge: {
     backgroundColor: {
       hasAllNoticesRead: '#9DA1A7',
-      hasUnreadNotices: '#DB0D0D'
+      hasUnreadNotices: '#DB0D0D',
+      hasFailed: '#000'
     }
   },
 


### PR DESCRIPTION
Regarding #801, despite the fact that we are waiting for design to implement, I wanted to propose this POC of a simple visual feedback when network is unavailable or backend does not respond rightfully. 

I made a little badge :  
![image](https://user-images.githubusercontent.com/3037833/116164005-361efc80-a6f9-11eb-8214-bcae7f242752.png)

That has a little tooltip : 
![image](https://user-images.githubusercontent.com/3037833/116164171-8eee9500-a6f9-11eb-88b1-e78d5d8db874.png)

It’s totally non-final, but it aims to open the discussion to finally have some feedback !

