### PR TITLE
chore: quicker git push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lint:css": "stylelint './src/**/*.{ts,tsx}'",
     "prettier": "prettier --write src/**/*.{ts,tsx} test/**/*.{ts,tsx,js} manifest/**/*.js webpack/*.js release.*.js",
     "verify": "yarn test && yarn typecheck && yarn lint && yarn build:chromium:production && yarn build-storybook",
+    "verify:quick": "yarn test && yarn typecheck && yarn lint",
     "analyze": "NODE_ENV=production webpack --mode=production --env.PLATFORM=chromium --env.ANALYZE",
     "storybook": "start-storybook -s ./src/assets --ci -p 6007 -c .storybook",
     "build-storybook": "build-storybook"
@@ -58,7 +59,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged ",
-      "pre-push": "yarn verify"
+      "pre-push": "yarn verify:quick"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Passes `git push` time from 4-5 minutes to 1min15 by *not* verifying that the build succeeds, and leave this check for CI jobs