### PR TITLE
Invalid date proposal

### DIFF
--- a/src/app/hooks/useChangeLanguage.ts
+++ b/src/app/hooks/useChangeLanguage.ts
@@ -1,4 +1,5 @@
-import i18n, { SupportedLanguage } from '../../i18n';
+import i18n from '../../i18n';
+import { SupportedLanguage } from 'i18n/config';
 import { useLocation } from 'react-router';
 
 const fr = 'fr';

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_LANGUAGE = 'en';
+export type SupportedLanguage = typeof DEFAULT_LANGUAGE | 'fr';

--- a/src/i18n/date.ts
+++ b/src/i18n/date.ts
@@ -1,20 +1,22 @@
 import { fr, enUS } from 'date-fns/locale';
+import { DEFAULT_LANGUAGE } from './config';
 
 export const DEFAULT_FORMAT = 'dd/LL/yyyy';
 
 const availableLocales: Record<string, Locale> = {
   fr,
-  en: enUS
+  [DEFAULT_LANGUAGE]: enUS
 };
 
-export const getLocale = (locale?: string): Locale | undefined => {
+export const getLocale = (locale?: string): Locale => {
   if (locale) {
-    const lng = Object.keys(availableLocales).find(
+    const localeKey = Object.keys(availableLocales).find(
       key => key === locale.substring(0, 2)
     );
-    if (lng) {
-      return availableLocales[lng];
+    if (localeKey) {
+      return availableLocales[localeKey];
     }
   }
-  return enUS;
+
+  return availableLocales[DEFAULT_LANGUAGE];
 };

--- a/src/i18n/format.ts
+++ b/src/i18n/format.ts
@@ -1,4 +1,4 @@
-import { format as dateFormat, parseISO, isDate } from 'date-fns';
+import { format as dateFormat, parseISO, isDate, isMatch } from 'date-fns';
 import { getLocale as getDateLocale, DEFAULT_FORMAT } from './date';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -10,9 +10,16 @@ export default function(value: any, format?: string, lng?: string) {
         locale: getDateLocale(lng)
       });
     } catch (e) {
-      return dateFormat(isoDate as Date, DEFAULT_FORMAT, {
-        locale: getDateLocale(lng)
-      });
+      if (e instanceof RangeError) {
+        // eslint-disable-next-line no-console
+        console.error(e.message);
+        // given date format was invalid, format with the default one
+        return dateFormat(isoDate as Date, DEFAULT_FORMAT, {
+          locale: getDateLocale(lng)
+        });
+      } else {
+        throw e;
+      }
     }
   }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,16 +3,14 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 import resources from './resources';
 import format from './format';
-
-export type SupportedLanguage = 'en' | 'fr';
-export const fallbackLng = 'en';
+import { DEFAULT_LANGUAGE } from './config';
 
 export const options = {
   resources,
   detection: {
     caches: []
   },
-  fallbackLng,
+  fallbackLng: DEFAULT_LANGUAGE,
   ns: ['extension', 'profiles'],
   defaultNS: 'extension',
   debug: true,


### PR DESCRIPTION
> Following discussions about #989 with @gregoirelacoste on __Slack__

In my opinion the formatting exception shouldn't be silenced at all since because it's supposed to happens at dev time and fixed at dev time. 
However I can understanding @gregoirelacoste feeling about this, "it might happens anyway", that's why I'm trying to propose a middleground here:
- show an error message in console for the dev
- use default format if and only if it's a range error (format error in date-fns) and rethrow if it's something else.

> Maybe smthing else to do with Sentry?

This might sound picky, but this is important to understand the different level of errors and how we define might deal with it; define our strategy.

This also add  a default language constant and use it in `getLocale` and fix the return type to `Locale` only.