### PR TITLE
fix(newBlocksFirefox): change test connected in Profile

### DIFF
--- a/src/app/profiles/App/Pages/Profiles/Profile/Profile.tsx
+++ b/src/app/profiles/App/Pages/Profiles/Profile/Profile.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import CenterContainer from 'components/atoms/CenterContainer';
 import {
-  AddToBrowserMessageBox,
   ExplainingVideoMessageBox,
   PrivacyMessageBox
 } from 'components/molecules/SidebarBox';
@@ -221,9 +220,7 @@ export const Profile = ({
       </MainCol>
 
       <Aside>
-        {connected === false && (
-          <ExplainingVideoMessageBox contributor={contributor} />
-        )}
+        {!connected && <ExplainingVideoMessageBox contributor={contributor} />}
         {connected && <PrivacyMessageBox />}
 
         <SimilarProfiles


### PR DESCRIPTION
related to #1027
The issues was connected === undefined don't match with connected === false in:
``` js
{connected === false && (
          <ExplainingVideoMessageBox contributor={contributor} />
        )}
```
I fixed with `!connected &&`
A question : in connected reducer initial state is connected = undefined, why undefined and not false ?