### PR TITLE
chore(safari): setup safari build and first automation

### DIFF
--- a/bin/update-safari-repo.sh
+++ b/bin/update-safari-repo.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd DisMoi
+git init
+git remote add origin git@github.com:dis-moi/extension-safari.git
+git fetch
+git reset origin/main
+git checkout -t origin/main
+git add .
+git config --global user.name "bullito"
+git config --global user.email "bully@dismoi.io"
+git commit -m "update build"
+git push origin HEAD

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -1,0 +1,52 @@
+# MacOS
+
+## Setup the machine
+
+Create a machine user with remote ssh access
+Open port for the machine to be reachable from the outside.
+Set up authorized key to login programmatically
+Add bully ssh keys to be able to clone git repository.
+
+Install __ohmyzsh__:
+```
+sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+```
+
+Install __homebrew__:
+```
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Or allow the group to write to homebrew directories if already installed by another user:
+```
+sudo chmod -R g+w /opt/homebrew/*
+```
+
+Add `/opt/homebrew/bin/` to your path:
+```
+sudo nano /etc/paths
+```
+
+Install `yarn`:
+```
+brew install yarn
+```
+
+## Build for Safari
+```
+yarn build:safari:production
+xcrun safari-web-extension-converter --bundle-identifier io.dismoi.extension --force --no-prompt --copy-resources --project-location . --app-name DisMoi build/production/safari
+```
+
+Update __Safari__ repository:
+```
+cd DisMoi
+git init
+git remote add origin git@github.com:dis-moi/extension-safari.git
+git fetch
+git reset origin/main
+git checkout -t origin/main
+git add .
+git commit -m "update build"
+git push origin HEAD
+```

--- a/manifest/csp.js
+++ b/manifest/csp.js
@@ -1,0 +1,18 @@
+const csp = require('content-security-policy-builder');
+
+module.exports = csp({
+  directives: {
+    'default-src': ['https://api.dismoi.io'],
+    'connect-src': [
+      'https://api.dismoi.io',
+      'https://sentry.io',
+      'https://stats.lmem.net',
+      'https://app.posthog.com'
+    ],
+    'script-src': ["'self'"],
+    'object-src': ["'self'"],
+    'img-src': ["'self'", 'https://api.dismoi.io', 'data:'],
+    'font-src': ["'self'", 'data:'],
+    'style-src': ["'unsafe-inline'"]
+  }
+});

--- a/manifest/production/chromium.js
+++ b/manifest/production/chromium.js
@@ -1,24 +1,9 @@
-const csp = require('content-security-policy-builder');
 const base = require('../base');
+const csp = require('../csp');
 
 module.exports = {
   ...base,
-  content_security_policy: csp({
-    directives: {
-      'default-src': ['https://api.dismoi.io'],
-      'connect-src': [
-        'https://api.dismoi.io',
-        'https://sentry.io',
-        'https://stats.lmem.net',
-        'https://app.posthog.com'
-      ],
-      'script-src': ["'self'"],
-      'object-src': ["'self'"],
-      'img-src': ["'self'", 'https://api.dismoi.io', 'data:'],
-      'font-src': ["'self'", 'data:'],
-      'style-src': ["'unsafe-inline'"]
-    }
-  }),
+  content_security_policy: csp,
   externally_connectable: {
     matches: ['https://*.dismoi.io/*'],
     accepts_tls_channel_id: false

--- a/manifest/production/safari.js
+++ b/manifest/production/safari.js
@@ -1,0 +1,11 @@
+const base = require('../base');
+const csp = require('../csp');
+
+module.exports = {
+  ...base,
+  background: {
+    ...base.background,
+    persistent: false
+  },
+  content_security_policy: csp
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build:chromium:staging": "NODE_ENV=staging yarn build:chromium",
     "build:chromium:proding": "NODE_ENV=proding yarn build:chromium",
     "build:chromium:production": "NODE_ENV=production yarn build:chromium",
+    "build:safari:production": "NODE_ENV=production webpack --mode=production --env.PLATFORM=safari && yarn convert:safari && ./bin/update-safari-repo.sh",
+    "convert:safari": "xcrun safari-web-extension-converter --bundle-identifier io.dismoi.extension --force --no-prompt --copy-resources --project-location . --app-name DisMoi build/production/safari",
     "build:firefox:staging": "NODE_ENV=staging yarn build:firefox",
     "build:firefox:proding": "NODE_ENV=proding yarn build:firefox",
     "build:firefox:production": "NODE_ENV=production yarn build:firefox",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,9 @@ module.exports = function webpack(env = {}, argv = {}) {
   const srcPath = path.resolve(__dirname, 'src');
 
   const { NODE_ENV, PLATFORM } = env;
+  if (!NODE_ENV) {
+    console.warn('/!\\ NODE_ENV is not defined /!\\')
+  }
   const buildPath = path.resolve(__dirname, getBuildPath(PLATFORM, NODE_ENV));
 
   console.info('Building package to: ', buildPath);


### PR DESCRIPTION
This is a first draft, I still need to figure out the best way to ssh to this machine to trigger macOS and iOS build from our current/future CI.

The `xcrun safari-web-extension-converter [...]` command override every files in target directory including the `.git` folder...
It means I cant first clone the repo and the run the file generation, so I must figure out a git strategy that would preserve other files added to the [safari repository](
https://github.com/dis-moi/extension-safari) (for example a README or a Github workflow, etc...)
