### PR TITLE
fix: bad xpath expression breaks matching for everyone

### DIFF
--- a/src/libs/domain/matchingContext.ts
+++ b/src/libs/domain/matchingContext.ts
@@ -45,10 +45,15 @@ export const filterContextsMatchingUrl = (
     urlMatchesContext(url, context)
   );
 
-export const doesTabContentMatchExpression = async (tab: Tab, xpath?: string) =>
+export const doesTabContentMatchExpression = async (
+  tab: Tab,
+  xpath: string,
+  matchingContextId: MatchingContext['id']
+) =>
   xpath
     ? sendContentScriptRequest<boolean>(tab, 'doesDocumentMatchExpression', [
-        xpath
+        xpath,
+        matchingContextId
       ])
     : Promise.resolve(true);
 
@@ -57,9 +62,12 @@ export const filterContextsMatchingTabContent = async (
   matchingContexts: MatchingContext[]
 ) => {
   const responses = await Promise.all(
-    matchingContexts.map(({ xpath }: MatchingContext) =>
-      doesTabContentMatchExpression(tab, xpath)
-    )
+    matchingContexts.map(({ xpath, id }: MatchingContext) => {
+      return (
+        typeof xpath === 'undefined' ||
+        doesTabContentMatchExpression(tab, xpath, id)
+      );
+    })
   );
 
   return matchingContexts.filter((_, index) => responses[index]);

--- a/src/libs/utils/doesDocumentMatchExpression.ts
+++ b/src/libs/utils/doesDocumentMatchExpression.ts
@@ -1,13 +1,27 @@
-const doesDocumentMatchExpression = (expression: string) => {
-  const { booleanValue } = document.evaluate(
-    expression,
-    document,
-    null,
-    XPathResult.BOOLEAN_TYPE,
-    null
-  );
+import { MatchingContext } from '../domain/matchingContext';
 
-  return booleanValue;
+const doesDocumentMatchExpression = (
+  expression: string,
+  matchingContextId: MatchingContext['id']
+) => {
+  try {
+    const { booleanValue } = document.evaluate(
+      expression,
+      document,
+      null,
+      XPathResult.BOOLEAN_TYPE,
+      null
+    );
+
+    return booleanValue;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[DisMoi] Could not evaluate XPath "${expression}" of matching ${matchingContextId}`
+    );
+
+    return false;
+  }
 };
 
 export default doesDocumentMatchExpression;


### PR DESCRIPTION
fixes #1127 

Problem was :
 - We filter in all matching contexts the ones which match current URL
 - We filter again the remaining list to check if an xpath expression applies
 - One notice has a bad xpath -> it breaks the whole matching for all notices, even those without XPath !
 
This commit  considers an xpath as non matching if the evaluation fails, and prints a warning to the website console.