### PR TITLE
Perf/filter matching lists at once

### DIFF
--- a/src/app/background/store/selectors/index.ts
+++ b/src/app/background/store/selectors/index.ts
@@ -1,17 +1,11 @@
 import { PersistedState } from 'redux-persist';
 import { createSelector } from 'reselect';
 import { InstallationDetails } from 'libs/domain/installation';
-import { filterContextsMatchingUrl } from 'libs/domain/matchingContext';
 import { getNotice } from 'libs/domain/notice';
 import { BackgroundState } from 'app/background/store/reducers';
-import { getMatchingContexts } from './resources';
 import { getInstallationDetails } from './installationDetails';
 import { areTosAccepted, getRead } from './prefs';
 import { getNoticesIdsOnTab } from './tabs';
-
-export const getContextsMatchingUrl = (state: BackgroundState) => (
-  url: string
-) => filterContextsMatchingUrl(url, getMatchingContexts(state));
 
 export const isAnUpdate = createSelector(
   getInstallationDetails,

--- a/src/libs/domain/matchingContext.ts
+++ b/src/libs/domain/matchingContext.ts
@@ -37,14 +37,6 @@ export const urlMatchesContext = (
   }
 };
 
-export const filterContextsMatchingUrl = (
-  url: string,
-  matchingContexts: MatchingContext[]
-) =>
-  matchingContexts.filter((context: MatchingContext) =>
-    urlMatchesContext(url, context)
-  );
-
 export const doesTabContentMatchExpression = async (
   tab: Tab,
   xpath: string,
@@ -57,18 +49,28 @@ export const doesTabContentMatchExpression = async (
       ])
     : Promise.resolve(true);
 
-export const filterContextsMatchingTabContent = async (
-  tab: Tab,
-  matchingContexts: MatchingContext[]
-) => {
+export const filterContexts = async (
+  matchingContexts: MatchingContext[],
+  tab: Tab
+): Promise<MatchingContext[]> => {
   const responses = await Promise.all(
-    matchingContexts.map(({ xpath, id }: MatchingContext) => {
-      return (
-        typeof xpath === 'undefined' ||
-        doesTabContentMatchExpression(tab, xpath, id)
-      );
+    matchingContexts.map((matchingContext: MatchingContext):
+      | Promise<MatchingContext | false>
+      | MatchingContext
+      | false => {
+      if (urlMatchesContext(tab.url, matchingContext)) {
+        if (!matchingContext.xpath) return matchingContext;
+
+        return doesTabContentMatchExpression(
+          tab,
+          matchingContext.xpath,
+          matchingContext.id
+        ).then((matchesContent: boolean) =>
+          matchesContent ? matchingContext : false
+        );
+      }
+      return false;
     })
   );
-
-  return matchingContexts.filter((_, index) => responses[index]);
+  return responses.filter(Boolean) as MatchingContext[];
 };

--- a/src/libs/domain/matchingContext.ts
+++ b/src/libs/domain/matchingContext.ts
@@ -54,23 +54,22 @@ export const filterContexts = async (
   tab: Tab
 ): Promise<MatchingContext[]> => {
   const responses = await Promise.all(
-    matchingContexts.map((matchingContext: MatchingContext):
-      | Promise<MatchingContext | false>
-      | MatchingContext
-      | false => {
-      if (urlMatchesContext(tab.url, matchingContext)) {
-        if (!matchingContext.xpath) return matchingContext;
+    matchingContexts.map(
+      (matchingContext: MatchingContext): Promise<MatchingContext | false> => {
+        if (urlMatchesContext(tab.url, matchingContext)) {
+          if (!matchingContext.xpath) return Promise.resolve(matchingContext);
 
-        return doesTabContentMatchExpression(
-          tab,
-          matchingContext.xpath,
-          matchingContext.id
-        ).then((matchesContent: boolean) =>
-          matchesContent ? matchingContext : false
-        );
+          return doesTabContentMatchExpression(
+            tab,
+            matchingContext.xpath,
+            matchingContext.id
+          ).then((matchesContent: boolean) =>
+            matchesContent ? matchingContext : false
+          );
+        }
+        return Promise.resolve(false);
       }
-      return false;
-    })
+    )
   );
   return responses.filter(Boolean) as MatchingContext[];
 };


### PR DESCRIPTION
To review once #1129 is merges, as this one is based on it … (or review only commit 09d67e5ed4c1071d2a2f19fcf12d291a2eae9829)

This is a little perf refacto that aim to filter matching contexts once instead of first filter for urlRegex and then filtering again for XPath …