### PR TITLE
fix: profiles and extension communication under Chromium

### DIFF
--- a/manifest/production/chromium.js
+++ b/manifest/production/chromium.js
@@ -20,7 +20,7 @@ module.exports = facet => ({
     }
   }),
   externally_connectable: {
-    matches: ['https://*.dismoi.io/*'],
+    matches: ['https://*.dismoi.io/*', 'https://*.lememe.fr/*'],
     accepts_tls_channel_id: false
   }
 });


### PR DESCRIPTION
Allow "https://*.lememe.fr" in externally_connectable